### PR TITLE
chore: bump initial release version to 0.1.0

### DIFF
--- a/docs/source.json
+++ b/docs/source.json
@@ -19,18 +19,18 @@
       "tintColor": "#000000",
       "category": "lifestyle",
       "screenshotURLs": [],
-      "version": "1.0.0",
-      "versionDate": "2026-04-26",
+      "version": "0.1.0",
+      "versionDate": "2026-04-27",
       "versionDescription": "Initial release.",
-      "downloadURL": "https://github.com/sugarshin/seam/releases/download/v1.0.0/Seam-v1.0.0.ipa",
-      "size": 9142842,
+      "downloadURL": "https://github.com/sugarshin/seam/releases/download/v0.1.0/Seam-v0.1.0.ipa",
+      "size": 0,
       "versions": [
         {
-          "version": "1.0.0",
-          "date": "2026-04-26",
+          "version": "0.1.0",
+          "date": "2026-04-27",
           "localizedDescription": "Initial release.",
-          "downloadURL": "https://github.com/sugarshin/seam/releases/download/v1.0.0/Seam-v1.0.0.ipa",
-          "size": 9142842,
+          "downloadURL": "https://github.com/sugarshin/seam/releases/download/v0.1.0/Seam-v0.1.0.ipa",
+          "size": 0,
           "minOSVersion": "15.1"
         }
       ]

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Seam",
     "slug": "seam",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "seam",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seam/app",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
## Summary

Initial tag is `v0.1.0`, not `v1.0.0`. Align all the places that hold the version string so the release workflow's `Verify version match` step accepts the v0.1.0 tag push.

- `packages/app/app.json` `expo.version`: 1.0.0 → 0.1.0
- `packages/app/package.json` version: 1.0.0 → 0.1.0
- `docs/source.json`: top-level `version` / `versionDate` / `versionDescription` / `downloadURL` / `size`, plus `versions[0]` updated to 0.1.0 / 2026-04-27 / `Seam-v0.1.0.ipa` URL. `size` reset to 0 since no IPA exists yet (will be filled in by the workflow on first release run).

## Tag re-pointing required after merge

The local `v0.1.0` tag currently points to `f1e90bc` (`Setup sidestore`), which has the old 1.0.0 in `app.json` — pushing it now would fail the workflow's verify step. Once this PR is merged:

```sh
git fetch origin
git checkout main && git pull
git tag -d v0.1.0                   # remove local tag at f1e90bc
git tag v0.1.0                      # re-tag at the merge commit (now has 0.1.0)
git push origin v0.1.0              # triggers .github/workflows/release.yml
```

## Test plan

- [x] `pnpm -r typecheck` passes locally.
- [ ] After merge, push v0.1.0 tag → `release` workflow runs → IPA built → GitHub Release created → `docs/source.json` auto-updated by github-actions[bot].
- [ ] iPhone SideStore picks up the new version after pull-to-refresh on the Sources tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)