### PR TITLE
ci: track .npmrc so CI gets node-linker=hoisted

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# React Native / Expo / Metro の transitive dep 解決は flat node_modules 前提なので
+# pnpm の symlink isolation を解除する。これは Expo 公式が monorepo ガイドで推奨する設定。
+node-linker=hoisted
+auto-install-peers=true
+strict-peer-dependencies=false


### PR DESCRIPTION
## Summary

The release workflow on `v0.1.0` failed at `Pod install`:

```
[!] Invalid `RNReanimated.podspec` file: different prefix: "" and "/Users/runner/work/seam/seam/packages/app/ios/Pods".
Error: Cannot find module 'react-native-worklets/package.json'
```

Root cause: the repo `.npmrc` (which sets `node-linker=hoisted` for the Expo monorepo) **was not in git**. User-global `~/.gitignore` filters out `.npmrc` (a common credential-safety pattern), so it never made it into the repo despite working locally. CI checked out without it, defaulted to pnpm's symlink-isolated layout, and:

- `react-native-worklets` (peer of Reanimated 4.x) ended up only in `node_modules/.pnpm/...`, so RNReanimated.podspec's `require.resolve("react-native-worklets/package.json")` couldn't see it.
- The Reanimated podspec hit the "different prefix" CocoaPods error because its on-disk files live behind a `.pnpm/` symlink that CocoaPods refuses to walk through.

## Fix

`git add -f .npmrc` (bypassing the global ignore). The file contains no secrets:

```ini
node-linker=hoisted
auto-install-peers=true
strict-peer-dependencies=false
```

These are pure build settings recommended by the [Expo monorepo guide](https://docs.expo.dev/guides/monorepos/) and totally safe to commit.

## What still needs to happen on the v0.1.0 release after merge

The current `v0.1.0` tag points to `c080cfd` (PR #8 merge), which doesn't yet have `.npmrc`. The release workflow won't pass on that commit. Two ways forward:

### Option A — re-tag v0.1.0 onto the merge of this PR (cleanest, preserves first-release semantics)

```sh
git fetch origin
git checkout main && git pull
git tag -d v0.1.0
git push origin :refs/tags/v0.1.0   # delete remote
git tag v0.1.0
git push origin v0.1.0              # triggers release.yml
```

Note: this requires `git push --force` semantics on tags via the `:` deletion. The previous (failed) GitHub Release for `v0.1.0` may need to be manually deleted in the UI as well, since `softprops/action-gh-release` will refuse to overwrite an existing release with the same tag.

### Option B — bump to v0.1.1 and skip a clean v0.1.0

```sh
# bump packages/app/app.json + package.json + docs/source.json to 0.1.1
# (or just push a new tag — v0.1.1 — as a tiny chore PR)
```

This avoids tag deletion drama at the cost of skipping a clean v0.1.0 in history.

## Test plan

- [x] Local `pnpm install --frozen-lockfile` succeeds (verified — `node_modules/react-native-worklets` is at root, hoisted as expected).
- [ ] After merge, the re-tagged v0.1.0 (or fresh v0.1.1) triggers `release.yml` → Pod install passes → IPA built → Release uploaded → source.json bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)