### PR TITLE
ci(release): make changelog work on the very first tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,11 +169,21 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.build-ipa.outputs.tag }}
-          writeToFile: false
+        env:
+          TAG: ${{ needs.build-ipa.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            CHANGES="Initial release."
+          else
+            CHANGES=$(git log --pretty=format:"- %s" "${PREV}..${TAG}")
+          fi
+          {
+            echo "changes<<__EOF__"
+            echo "$CHANGES"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

The `release` workflow on `v0.1.0` failed in the **Generate changelog** step:

```
Using input tag: v0.1.0
Error: Couldn't find a previous tag. Make sure you have at least 2 tags already (current tag + previous initial tag).
```

`requarks/changelog-action@v1` requires a previous tag to diff against and has no built-in fallback for the very first release. Swap it for a small inline shell step that handles both cases.

## Behavior

- **Subsequent releases** (PREV tag exists): emits `git log --pretty=format:"- %s" PREV..TAG`.
- **First release** (no PREV tag): emits `Initial release.`

The output is still exposed at `steps.changelog.outputs.changes`, so `softprops/action-gh-release` and `update-source.mjs` continue to consume it unchanged.

Verified locally with `TAG=v0.1.0` against the current main — `git describe --tags --abbrev=0 v0.1.0^` returns nothing (no previous tag), and the fallback branch fires correctly.

## What still needs to happen on v0.1.0 after merge

The `v0.1.0` tag points to the previous main; once this PR merges, the tag needs to be re-pointed at the new HEAD so the workflow re-runs against a commit that has the fixed changelog step:

```sh
git fetch origin
git checkout main && git pull
git tag -d v0.1.0
git push origin :refs/tags/v0.1.0   # delete remote
git tag v0.1.0
git push origin v0.1.0              # triggers release.yml
```

If a (failed) `v0.1.0` GitHub Release was somehow created during prior attempts, delete it first so `softprops/action-gh-release` can recreate cleanly:

```sh
gh release view v0.1.0   # check first
gh release delete v0.1.0 --yes
```

## Test plan

- [x] Local shell snippet (`git describe --tags --abbrev=0 v0.1.0^ || true`) returns empty, fallback path runs.
- [ ] After merge + re-tag: `release` workflow succeeds end-to-end → IPA appears at `https://github.com/sugarshin/seam/releases/download/v0.1.0/Seam-v0.1.0.ipa` → `docs/source.json` size/sha update committed back to main by `github-actions[bot]`.
- [ ] iPhone SideStore: pull-to-refresh on Sources tab → UPDATE button works (downloads the actual IPA, not 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)