### PR TITLE
ci: add expo export step to catch Metro/codegen failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: pnpm -r test
 
+      - name: Build (Metro bundle)
+        run: pnpm --filter @seam/app exec expo export --platform ios --output-dir .expo/export-check
+
       # Maestro flows are skipped here — they need a real iOS simulator which
       # GitHub-hosted ubuntu runners can't provide. Run them locally with the
       # `maestro test .maestro/` command (see README).


### PR DESCRIPTION
## Summary
- `typecheck` と unit test では Metro bundling を走らせていないため、`babel-preset-expo` 同梱の `@react-native/codegen` と RN 本体のバージョンずれによる codegen エラーが CI を素通りする問題があった（直近の RN 0.85.2 取り込みで顕在化）。
- `expo export --platform ios` を CI に追加し、bundling フェーズまで実行することで、同種の transform/codegen 失敗を確実に検出できるようにする。

## Test plan
- [x] ローカルで `pnpm --filter @seam/app exec expo export --platform ios --output-dir .expo/export-check` が成功することを確認
- [ ] この PR の GitHub Actions `test` ジョブで新しい `Build (Metro bundle)` ステップがグリーンになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)