### PR TITLE
chore: drop unused deps and introduce Biome formatter + ESLint

### DIFF
--- a/.github/scripts/update-source.mjs
+++ b/.github/scripts/update-source.mjs
@@ -9,9 +9,7 @@ const IPA_SIZE = Number(process.env.IPA_SIZE);
 const CHANGES = process.env.CHANGES || '';
 
 if (!REPO || !TAG || !VERSION || !Number.isFinite(IPA_SIZE)) {
-  throw new Error(
-    `missing env: REPO=${REPO} TAG=${TAG} VERSION=${VERSION} IPA_SIZE=${IPA_SIZE}`,
-  );
+  throw new Error(`missing env: REPO=${REPO} TAG=${TAG} VERSION=${VERSION} IPA_SIZE=${IPA_SIZE}`);
 }
 
 const downloadURL = `https://github.com/${REPO}/releases/download/${TAG}/Seam-${TAG}.ipa`;
@@ -32,10 +30,7 @@ const newVersion = {
   minOSVersion: '15.1',
 };
 
-app.versions = [
-  newVersion,
-  ...(app.versions || []).filter((v) => v.version !== VERSION),
-];
+app.versions = [newVersion, ...(app.versions || []).filter((v) => v.version !== VERSION)];
 
 app.version = newVersion.version;
 app.versionDate = newVersion.date;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm -r lint
+
       - name: Typecheck
         run: pnpm -r typecheck
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.mjs",
+      "**/*.cjs",
+      "**/*.json",
+      "!**/node_modules",
+      "!**/.turbo",
+      "!**/.expo",
+      "!**/dist",
+      "!**/build",
+      "!**/ios",
+      "!**/android",
+      "!packages/app/src/db/migrations/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
     "dev": "turbo run dev --parallel",
     "clean": "turbo run clean && rm -rf node_modules .turbo"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.13",
     "turbo": "2.9.6",
     "typescript": "5.9.3"
   },

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -15,12 +15,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.sugarshin.seam"
     },
-    "plugins": [
-      "expo-router",
-      "expo-sqlite",
-      "expo-image-picker",
-      "expo-secure-store"
-    ],
+    "plugins": ["expo-router", "expo-sqlite", "expo-image-picker", "expo-secure-store"],
     "experiments": {
       "typedRoutes": true
     }

--- a/packages/app/app/(tabs)/closet.tsx
+++ b/packages/app/app/(tabs)/closet.tsx
@@ -24,7 +24,7 @@ import { itemRepository, photoRepository, wearLogRepository } from '../../src/re
 import type { ItemSort } from '../../src/repositories';
 import { colors, font, radii, space } from '../../src/theme';
 
-const SORT_OPTIONS: ReadonlyArray<PickerOption<ItemSort>> = [
+const SORT_OPTIONS: readonly PickerOption<ItemSort>[] = [
   { value: 'createdAt_desc', label: '新しい順' },
   { value: 'purchaseDate_desc', label: '購入日が新しい順' },
   { value: 'purchasePrice_desc', label: '価格が高い順' },
@@ -95,9 +95,7 @@ export default function ClosetScreen() {
       item={item}
       thumbnailRelativePath={thumbnails[item.id]}
       wearCount={wearCounts[item.id]}
-      onPress={() =>
-        router.push({ pathname: '/item/[id]', params: { id: item.id } })
-      }
+      onPress={() => router.push({ pathname: '/item/[id]', params: { id: item.id } })}
     />
   );
 

--- a/packages/app/app/(tabs)/compare.tsx
+++ b/packages/app/app/(tabs)/compare.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View, type ViewStyle } from 'react-native';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import {
   CATEGORY_LABEL,
@@ -30,11 +23,7 @@ import { Picker, type PickerOption } from '../../src/components/Picker';
 import { ScoreBadge } from '../../src/components/ScoreBadge';
 import { ScoreBreakdown } from '../../src/components/ScoreBreakdown';
 import { SeverityBadge } from '../../src/components/SeverityBadge';
-import {
-  fitAnchorRepository,
-  itemRepository,
-  measurementRepository,
-} from '../../src/repositories';
+import { fitAnchorRepository, itemRepository, measurementRepository } from '../../src/repositories';
 import {
   computeCandidateScore,
   recordDecision,
@@ -60,7 +49,8 @@ type OwnedLite = {
 
 export default function CompareScreen() {
   const params = useLocalSearchParams<{ candidateId?: string }>();
-  const initialCandidateId = typeof params.candidateId === 'string' ? params.candidateId : undefined;
+  const initialCandidateId =
+    typeof params.candidateId === 'string' ? params.candidateId : undefined;
 
   const [candidates, setCandidates] = useState<GarmentItem[]>([]);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string | undefined>(
@@ -118,9 +108,7 @@ export default function CompareScreen() {
       setAnchors(anchorEnriched.filter((x): x is AnchorLite => x !== null));
 
       const ownedAll = await itemRepository.listOwned();
-      const ownedSameCat = ownedAll.filter(
-        (o) => o.category === item.category && o.id !== item.id,
-      );
+      const ownedSameCat = ownedAll.filter((o) => o.category === item.category && o.id !== item.id);
       const ownedEnriched = await Promise.all(
         ownedSameCat.map(async (o) => ({
           item: o,
@@ -152,7 +140,7 @@ export default function CompareScreen() {
     return suggestSimilarItems(candidate.item, ownedItems, { limit: 5 });
   }, [candidate, ownedSameCategory]);
 
-  const candidateOptions: ReadonlyArray<PickerOption<string>> = useMemo(
+  const candidateOptions: readonly PickerOption<string>[] = useMemo(
     () => candidates.map((c) => ({ value: c.id, label: c.name })),
     [candidates],
   );
@@ -312,16 +300,11 @@ export default function CompareScreen() {
                     <Pressable
                       accessibilityRole="button"
                       onPress={() => setExpandedOwnedId(expanded ? null : o.item.id)}
-                      style={({ pressed }) => [
-                        ownedHeader,
-                        pressed && { opacity: 0.7 },
-                      ]}
+                      style={({ pressed }) => [ownedHeader, pressed && { opacity: 0.7 }]}
                     >
                       <View style={{ flex: 1 }}>
                         <Text style={ownedName}>{o.item.name}</Text>
-                        {o.item.brand && (
-                          <Text style={ownedSubtitle}>{o.item.brand}</Text>
-                        )}
+                        {o.item.brand && <Text style={ownedSubtitle}>{o.item.brand}</Text>}
                       </View>
                       <Text style={chevron}>{expanded ? '▾' : '▸'}</Text>
                     </Pressable>
@@ -370,11 +353,7 @@ export default function CompareScreen() {
               onPress={() => setDecisionDraft('watch')}
               variant="secondary"
             />
-            <Button
-              label="Skip にする"
-              onPress={() => setDecisionDraft('skip')}
-              variant="ghost"
-            />
+            <Button label="Skip にする" onPress={() => setDecisionDraft('skip')} variant="ghost" />
           </View>
         </>
       )}

--- a/packages/app/app/(tabs)/index.tsx
+++ b/packages/app/app/(tabs)/index.tsx
@@ -1,18 +1,10 @@
 import { useCallback, useState } from 'react';
 import { ScrollView, Text, View, type ViewStyle } from 'react-native';
 import { useFocusEffect, router } from 'expo-router';
-import {
-  CANDIDATE_STATUSES,
-  type CandidateInfo,
-  type GarmentItem,
-} from '@seam/shared';
+import { CANDIDATE_STATUSES, type CandidateInfo, type GarmentItem } from '@seam/shared';
 import { EmptyState } from '../../src/components/EmptyState';
 import { ItemCard } from '../../src/components/ItemCard';
-import {
-  candidateInfoRepository,
-  itemRepository,
-  photoRepository,
-} from '../../src/repositories';
+import { candidateInfoRepository, itemRepository, photoRepository } from '../../src/repositories';
 import { getMonthlyPurchaseSummary } from '../../src/stats';
 import { colors, font, space, useThemeColors } from '../../src/theme';
 
@@ -36,10 +28,7 @@ export default function HomeScreen() {
 
   const load = useCallback(async () => {
     const owned = await itemRepository.list({ statuses: ['owned'] }, 'createdAt_desc');
-    const wishlist = await itemRepository.list(
-      { statuses: CANDIDATE_STATUSES },
-      'createdAt_desc',
-    );
+    const wishlist = await itemRepository.list({ statuses: CANDIDATE_STATUSES }, 'createdAt_desc');
     const ownedTop = owned.slice(0, TOP_N);
     const wishTop = wishlist.slice(0, TOP_N);
     setRecentOwned(ownedTop);

--- a/packages/app/app/(tabs)/settings.tsx
+++ b/packages/app/app/(tabs)/settings.tsx
@@ -83,28 +83,27 @@ export default function SettingsScreen() {
     }
   };
 
-  const runImport = useCallback(async (uri: string, mode: ImportMode): Promise<void> => {
-    setBusy(true);
-    try {
-      const result: ImportResult = await importFromJsonFile(uri, { mode });
-      const totals = Object.entries(result.insertedCounts)
-        .filter(([, n]) => n > 0)
-        .map(([t, n]) => `${t}: ${n}`)
-        .join('\n');
-      const summary = totals.length > 0 ? totals : '挿入された行はありません。';
-      const errors =
-        result.errors.length > 0 ? `\n\nエラー:\n${result.errors.join('\n')}` : '';
-      Alert.alert('インポート完了', `${summary}${errors}`);
-      await refreshExportState();
-    } catch (err) {
-      Alert.alert(
-        'インポート失敗',
-        err instanceof Error ? err.message : String(err),
-      );
-    } finally {
-      setBusy(false);
-    }
-  }, [refreshExportState]);
+  const runImport = useCallback(
+    async (uri: string, mode: ImportMode): Promise<void> => {
+      setBusy(true);
+      try {
+        const result: ImportResult = await importFromJsonFile(uri, { mode });
+        const totals = Object.entries(result.insertedCounts)
+          .filter(([, n]) => n > 0)
+          .map(([t, n]) => `${t}: ${n}`)
+          .join('\n');
+        const summary = totals.length > 0 ? totals : '挿入された行はありません。';
+        const errors = result.errors.length > 0 ? `\n\nエラー:\n${result.errors.join('\n')}` : '';
+        Alert.alert('インポート完了', `${summary}${errors}`);
+        await refreshExportState();
+      } catch (err) {
+        Alert.alert('インポート失敗', err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [refreshExportState],
+  );
 
   const onImport = useCallback(async (): Promise<void> => {
     const picked = await DocumentPicker.getDocumentAsync({
@@ -116,39 +115,31 @@ export default function SettingsScreen() {
     if (!asset) return;
     const uri = asset.uri;
 
-    Alert.alert(
-      'インポート方法',
-      '既存のデータをどうしますか？',
-      [
-        { text: 'キャンセル', style: 'cancel' },
-        {
-          text: 'マージ (重複は無視)',
-          onPress: () => {
-            void runImport(uri, 'merge');
-          },
+    Alert.alert('インポート方法', '既存のデータをどうしますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: 'マージ (重複は無視)',
+        onPress: () => {
+          void runImport(uri, 'merge');
         },
-        {
-          text: '上書き (全削除→復元)',
-          style: 'destructive',
-          onPress: () => {
-            Alert.alert(
-              '本当に上書きしますか？',
-              '既存のデータはすべて削除されます。',
-              [
-                { text: 'キャンセル', style: 'cancel' },
-                {
-                  text: '上書き実行',
-                  style: 'destructive',
-                  onPress: () => {
-                    void runImport(uri, 'replace');
-                  },
-                },
-              ],
-            );
-          },
+      },
+      {
+        text: '上書き (全削除→復元)',
+        style: 'destructive',
+        onPress: () => {
+          Alert.alert('本当に上書きしますか？', '既存のデータはすべて削除されます。', [
+            { text: 'キャンセル', style: 'cancel' },
+            {
+              text: '上書き実行',
+              style: 'destructive',
+              onPress: () => {
+                void runImport(uri, 'replace');
+              },
+            },
+          ]);
         },
-      ],
-    );
+      },
+    ]);
   }, [runImport]);
 
   return (
@@ -169,10 +160,7 @@ export default function SettingsScreen() {
           accessibilityLabel="JSON エクスポート"
           disabled={busy}
           onPress={onExport}
-          style={({ pressed }) => [
-            styles.btn,
-            (pressed || busy) && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btn, (pressed || busy) && { opacity: 0.6 }]}
         >
           <Text style={styles.btnLabel}>{busy ? '処理中…' : 'JSON エクスポート'}</Text>
         </Pressable>
@@ -183,10 +171,7 @@ export default function SettingsScreen() {
           accessibilityLabel="CSV エクスポート"
           disabled={busy}
           onPress={onExportCsv}
-          style={({ pressed }) => [
-            styles.btnSecondary,
-            (pressed || busy) && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btnSecondary, (pressed || busy) && { opacity: 0.6 }]}
         >
           <Text style={styles.btnSecondaryLabel}>CSV エクスポート (アイテム)</Text>
         </Pressable>
@@ -198,10 +183,7 @@ export default function SettingsScreen() {
           onPress={() => {
             void onImport();
           }}
-          style={({ pressed }) => [
-            styles.btnSecondary,
-            (pressed || busy) && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btnSecondary, (pressed || busy) && { opacity: 0.6 }]}
         >
           <Text style={styles.btnSecondaryLabel}>JSON インポート</Text>
         </Pressable>
@@ -216,10 +198,7 @@ export default function SettingsScreen() {
         <Pressable
           accessibilityRole="button"
           onPress={() => router.push('/settings/measurement-rules')}
-          style={({ pressed }) => [
-            styles.btn,
-            pressed && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btn, pressed && { opacity: 0.6 }]}
         >
           <Text style={styles.btnLabel}>個人 NG / Warning ルール</Text>
         </Pressable>
@@ -233,10 +212,7 @@ export default function SettingsScreen() {
         <Pressable
           accessibilityRole="button"
           onPress={() => router.push('/settings/brand-guides')}
-          style={({ pressed }) => [
-            styles.btn,
-            pressed && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btn, pressed && { opacity: 0.6 }]}
         >
           <Text style={styles.btnLabel}>ブランド別 見るべきポイント</Text>
         </Pressable>
@@ -252,10 +228,7 @@ export default function SettingsScreen() {
           accessibilityLabel="データを全削除"
           disabled={busy}
           onPress={() => router.push('/settings/data-reset')}
-          style={({ pressed }) => [
-            styles.btnDestructive,
-            (pressed || busy) && { opacity: 0.6 },
-          ]}
+          style={({ pressed }) => [styles.btnDestructive, (pressed || busy) && { opacity: 0.6 }]}
         >
           <Text style={styles.btnDestructiveLabel}>データを全削除…</Text>
         </Pressable>
@@ -266,9 +239,7 @@ export default function SettingsScreen() {
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>アプリ情報</Text>
-        <Text style={styles.kv}>
-          version: {Application.nativeApplicationVersion ?? '0.0.1'}
-        </Text>
+        <Text style={styles.kv}>version: {Application.nativeApplicationVersion ?? '0.0.1'}</Text>
       </View>
     </ScrollView>
   );

--- a/packages/app/app/(tabs)/stats.tsx
+++ b/packages/app/app/(tabs)/stats.tsx
@@ -155,8 +155,7 @@ export default function StatsScreen() {
             label: u.name,
             sublabel: `${u.daysSincePurchase} 日経過`,
             trailing: '0回',
-            onPress: () =>
-              router.push({ pathname: '/item/[id]', params: { id: u.id } }),
+            onPress: () => router.push({ pathname: '/item/[id]', params: { id: u.id } }),
           }))}
           emptyMessage="着ていない服はありません 🎉"
         />
@@ -165,11 +164,9 @@ export default function StatsScreen() {
       <Section title="重複の可能性" subtitle="同じカテゴリ × ブランド × 色">
         <RankingList
           items={snapshot.duplicateClusters.map((c, idx) => {
-            const parts = [
-              CATEGORY_LABEL[c.category],
-              c.brand,
-              c.color,
-            ].filter((p): p is string => Boolean(p));
+            const parts = [CATEGORY_LABEL[c.category], c.brand, c.color].filter((p): p is string =>
+              Boolean(p),
+            );
             return {
               id: `${c.category}-${c.brand ?? '-'}-${c.color ?? '-'}-${idx}`,
               label: parts.join(' · '),
@@ -188,8 +185,7 @@ export default function StatsScreen() {
             label: i.name,
             sublabel: `着用 ${i.wearCount} 回`,
             trailing: `¥${Math.round(i.cpw).toLocaleString()}`,
-            onPress: () =>
-              router.push({ pathname: '/item/[id]', params: { id: i.id } }),
+            onPress: () => router.push({ pathname: '/item/[id]', params: { id: i.id } }),
           }))}
           emptyMessage="CPW を計算できるアイテムがまだありません"
         />

--- a/packages/app/app/(tabs)/wishlist.tsx
+++ b/packages/app/app/(tabs)/wishlist.tsx
@@ -23,27 +23,23 @@ import { Chip } from '../../src/components/Chip';
 import { EmptyState } from '../../src/components/EmptyState';
 import { ItemCard } from '../../src/components/ItemCard';
 import { Picker, type PickerOption } from '../../src/components/Picker';
-import {
-  candidateInfoRepository,
-  itemRepository,
-  photoRepository,
-} from '../../src/repositories';
+import { candidateInfoRepository, itemRepository, photoRepository } from '../../src/repositories';
 import { colors, font, radii, space } from '../../src/theme';
 
 type WishSort = 'auctionEndsAt_asc' | 'price_asc' | 'createdAt_desc';
 
-const SORT_OPTIONS: ReadonlyArray<PickerOption<WishSort>> = [
+const SORT_OPTIONS: readonly PickerOption<WishSort>[] = [
   { value: 'auctionEndsAt_asc', label: '終了日時が近い順' },
   { value: 'price_asc', label: '価格が安い順' },
   { value: 'createdAt_desc', label: '追加日が新しい順' },
 ];
 
-const STATUS_FILTER_OPTIONS: ReadonlyArray<PickerOption<ItemStatus | '__all__'>> = [
+const STATUS_FILTER_OPTIONS: readonly PickerOption<ItemStatus | '__all__'>[] = [
   { value: '__all__', label: 'すべてのステータス' },
   ...CANDIDATE_STATUSES.map((s) => ({ value: s, label: ITEM_STATUS_LABEL[s] })),
 ];
 
-const SOURCE_FILTER_OPTIONS: ReadonlyArray<PickerOption<SourceType | '__all__'>> = [
+const SOURCE_FILTER_OPTIONS: readonly PickerOption<SourceType | '__all__'>[] = [
   { value: '__all__', label: 'すべての出品元' },
   ...SOURCE_TYPES.map((s) => ({ value: s, label: SOURCE_TYPE_LABEL[s] })),
 ];
@@ -89,10 +85,7 @@ export default function WishlistScreen() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const items = await itemRepository.list(
-        { statuses: CANDIDATE_STATUSES },
-        'createdAt_desc',
-      );
+      const items = await itemRepository.list({ statuses: CANDIDATE_STATUSES }, 'createdAt_desc');
       const enriched: WishItem[] = await Promise.all(
         items.map(async (item) => {
           const [candidate, photos] = await Promise.all([
@@ -137,15 +130,11 @@ export default function WishlistScreen() {
         <ItemCard
           item={item.item}
           thumbnailRelativePath={item.thumbnail}
-          onPress={() =>
-            router.push({ pathname: '/candidate/[id]', params: { id: item.item.id } })
-          }
+          onPress={() => router.push({ pathname: '/candidate/[id]', params: { id: item.item.id } })}
         />
         {(total !== undefined || ends !== undefined) && (
           <View style={metaRow}>
-            {total !== undefined && (
-              <Text style={metaPrice}>¥{total.toLocaleString()}</Text>
-            )}
+            {total !== undefined && <Text style={metaPrice}>¥{total.toLocaleString()}</Text>}
             {ends && <Text style={metaEnds}>～ {ends.replace('T', ' ').slice(0, 16)}</Text>}
           </View>
         )}

--- a/packages/app/app/candidate/[id].tsx
+++ b/packages/app/app/candidate/[id].tsx
@@ -66,7 +66,11 @@ import {
   tagRepository,
   updateItemWithDetails,
 } from '../../src/repositories';
-import { computeCandidateScore, recordDecision, type ComputeCandidateScoreResult } from '../../src/scoring';
+import {
+  computeCandidateScore,
+  recordDecision,
+  type ComputeCandidateScoreResult,
+} from '../../src/scoring';
 import { colors, font, radii, space } from '../../src/theme';
 
 type LoadedCandidate = {
@@ -92,13 +96,7 @@ const LEAD_TIME_MS_LOOKUP: Record<ReminderLeadTime, number> = {
   '1d': 24 * 60 * 60 * 1000,
 };
 
-const ALL_LEAD_TIMES_TUPLE: readonly ReminderLeadTime[] = [
-  '10m',
-  '30m',
-  '1h',
-  '3h',
-  '1d',
-];
+const ALL_LEAD_TIMES_TUPLE: readonly ReminderLeadTime[] = ['10m', '30m', '1h', '3h', '1d'];
 
 /**
  * Recover the lead-time labels currently configured by inspecting how many
@@ -140,8 +138,7 @@ const DECISION_TONE: Record<DecisionLog['decision'], string> = {
   lost_auction: colors.textMuted,
 };
 
-const formatYen = (n?: number): string =>
-  n !== undefined ? `¥${n.toLocaleString()}` : '—';
+const formatYen = (n?: number): string => (n !== undefined ? `¥${n.toLocaleString()}` : '—');
 
 const formatDate = (iso?: string): string => {
   if (!iso) return '—';
@@ -194,9 +191,7 @@ export default function CandidateDetailScreen() {
       decisionLogRepository.listByItem(itemId),
       reminderRepository.listByItem(itemId),
     ]);
-    const brandGuides = item.brand
-      ? await brandGuideRepository.listByBrand(item.brand)
-      : [];
+    const brandGuides = item.brand ? await brandGuideRepository.listByBrand(item.brand) : [];
     const brandChecklistStates: Record<string, BrandChecklistState[]> = {};
     await Promise.all(
       brandGuides.map(async (g) => {
@@ -250,7 +245,6 @@ export default function CandidateDetailScreen() {
         const formIds = new Set(input.photos.map((p) => p.id));
         for (const e of existing) {
           if (!formIds.has(e.id)) {
-            // eslint-disable-next-line no-await-in-loop
             await photoRepository.delete(e.id);
           }
         }
@@ -259,7 +253,7 @@ export default function CandidateDetailScreen() {
           const p = input.photos[i];
           if (!p) continue;
           if (existingIds.has(p.id)) continue;
-          // eslint-disable-next-line no-await-in-loop
+
           await photoRepository.create(itemId, p.relativePath, p.thumbnailRelativePath, i);
         }
         setEditing(false);
@@ -371,10 +365,7 @@ export default function CandidateDetailScreen() {
           const kept: MeasurementInput[] = loaded.measurements
             .filter((m) => !adoptedKeys.has(m.key))
             .map(({ itemId: iid, key, value, unit }) => ({ itemId: iid, key, value, unit }));
-          const next: MeasurementInput[] = [
-            ...kept,
-            ...adopted.map((m) => ({ ...m, itemId })),
-          ];
+          const next: MeasurementInput[] = [...kept, ...adopted.map((m) => ({ ...m, itemId }))];
           await measurementRepository.upsertForItem(itemId, next);
           setExtractionVisible(false);
           await refresh();
@@ -458,7 +449,6 @@ export default function CandidateDetailScreen() {
           });
 
           for (const r of scheduled) {
-            // eslint-disable-next-line no-await-in-loop -- sequential keeps inserts predictable
             await reminderRepository.create({
               itemId,
               remindAt: r.remindAt,
@@ -468,10 +458,7 @@ export default function CandidateDetailScreen() {
           }
 
           if (scheduled.length === 0 && result.leadTimes.length > 0) {
-            Alert.alert(
-              '通知をスケジュールできませんでした',
-              '選択した時刻はすでに過ぎています。',
-            );
+            Alert.alert('通知をスケジュールできませんでした', '選択した時刻はすでに過ぎています。');
           }
 
           setReminderModalVisible(false);
@@ -565,14 +552,11 @@ export default function CandidateDetailScreen() {
               fitAnchorName: loaded.anchor?.name,
               fitAnchorNotes: loaded.anchor?.notes,
               sourceType: c?.sourceType,
-              candidateCurrentPrice:
-                c?.currentPrice !== undefined ? String(c.currentPrice) : '',
-              candidateShippingFee:
-                c?.shippingFee !== undefined ? String(c.shippingFee) : '',
+              candidateCurrentPrice: c?.currentPrice !== undefined ? String(c.currentPrice) : '',
+              candidateShippingFee: c?.shippingFee !== undefined ? String(c.shippingFee) : '',
               auctionEndsAt: c?.auctionEndsAt,
               easyBuyPrice: c?.easyBuyPrice !== undefined ? String(c.easyBuyPrice) : '',
-              acceptablePrice:
-                c?.acceptablePrice !== undefined ? String(c.acceptablePrice) : '',
+              acceptablePrice: c?.acceptablePrice !== undefined ? String(c.acceptablePrice) : '',
               maxBidPrice: c?.maxBidPrice !== undefined ? String(c.maxBidPrice) : '',
               sellerName: c?.sellerName,
               listingDescription: c?.listingDescription,
@@ -656,12 +640,8 @@ export default function CandidateDetailScreen() {
                 totalScore={loaded.latestEvaluation.totalScore}
                 decision={loaded.latestEvaluation.decision}
               />
-              <ScoreBreakdown
-                breakdown={breakdownFromEvaluation(loaded.latestEvaluation)}
-              />
-              <Text style={muted}>
-                記録日時: {formatDate(loaded.latestEvaluation.createdAt)}
-              </Text>
+              <ScoreBreakdown breakdown={breakdownFromEvaluation(loaded.latestEvaluation)} />
+              <Text style={muted}>記録日時: {formatDate(loaded.latestEvaluation.createdAt)}</Text>
             </View>
           </View>
         )}
@@ -679,16 +659,18 @@ export default function CandidateDetailScreen() {
             {c.sellerName && <Kv k="出品者" v={c.sellerName} />}
             {loaded.item.productUrl && <Kv k="URL" v={loaded.item.productUrl} />}
             {c.listingDescription && <Kv k="説明" v={c.listingDescription} />}
-            {overBudget && (
-              <Text style={warning}>合計が上限価格を超えています</Text>
-            )}
+            {overBudget && <Text style={warning}>合計が上限価格を超えています</Text>}
           </View>
         )}
 
         <View style={section}>
           <View style={snapshotsHeader}>
             <Text style={sectionTitle}>価格スナップショット</Text>
-            <Text accessibilityRole="button" onPress={() => void recordCurrentPrice()} style={addLink}>
+            <Text
+              accessibilityRole="button"
+              onPress={() => void recordCurrentPrice()}
+              style={addLink}
+            >
               ＋現在価格を記録
             </Text>
           </View>
@@ -737,9 +719,7 @@ export default function CandidateDetailScreen() {
             {loaded.brandGuides.map((g) => (
               <View key={g.id} style={brandGuideCard}>
                 <Text style={brandGuideTitle}>{g.title}</Text>
-                {g.notes.length > 0 && (
-                  <Text style={brandGuideNotes}>{g.notes}</Text>
-                )}
+                {g.notes.length > 0 && <Text style={brandGuideNotes}>{g.notes}</Text>}
                 <View style={{ marginTop: space.sm }}>
                   <BrandChecklist
                     guide={g}
@@ -855,11 +835,7 @@ export default function CandidateDetailScreen() {
             variant="secondary"
           />
           <Button label="Buy として記録" onPress={() => openDecision('buy')} />
-          <Button
-            label="Watch にする"
-            onPress={() => openDecision('watch')}
-            variant="secondary"
-          />
+          <Button label="Watch にする" onPress={() => openDecision('watch')} variant="secondary" />
           <Button label="Skip にする" onPress={() => openDecision('skip')} variant="ghost" />
           <Button label="Lost Auction にする" onPress={markLostAuction} variant="ghost" />
           <Button label="編集" onPress={() => setEditing(true)} variant="ghost" />
@@ -908,7 +884,9 @@ export default function CandidateDetailScreen() {
 const Kv = ({ k, v, emphasize }: { k: string; v: string; emphasize?: boolean }) => (
   <View style={kvRow}>
     <Text style={kvKey}>{k}</Text>
-    <Text style={[kvVal, emphasize ? { color: colors.warning, fontWeight: font.weight.bold } : null]}>
+    <Text
+      style={[kvVal, emphasize ? { color: colors.warning, fontWeight: font.weight.bold } : null]}
+    >
       {v}
     </Text>
   </View>

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -62,8 +62,7 @@ type LoadedItem = {
   saleInfo: SaleInfo | null;
 };
 
-const formatYen = (n?: number): string =>
-  n !== undefined ? `¥${n.toLocaleString()}` : '—';
+const formatYen = (n?: number): string => (n !== undefined ? `¥${n.toLocaleString()}` : '—');
 
 const formatDate = (iso?: string | null): string => {
   if (!iso) return '—';
@@ -165,7 +164,6 @@ export default function ItemDetailScreen() {
         // delete photos not present
         for (const e of existing) {
           if (!formIds.has(e.id)) {
-            // eslint-disable-next-line no-await-in-loop -- sequential is fine
             await photoRepository.delete(e.id);
           }
         }
@@ -175,7 +173,7 @@ export default function ItemDetailScreen() {
           const p = input.photos[i];
           if (!p) continue;
           if (existingIds.has(p.id)) continue;
-          // eslint-disable-next-line no-await-in-loop
+
           await photoRepository.create(itemId, p.relativePath, p.thumbnailRelativePath, i);
         }
         setEditing(false);
@@ -458,11 +456,7 @@ export default function ItemDetailScreen() {
           title: loaded.item.name,
           headerShown: true,
           headerRight: () => (
-            <Text
-              accessibilityRole="button"
-              onPress={() => setEditing(true)}
-              style={editLink}
-            >
+            <Text accessibilityRole="button" onPress={() => setEditing(true)} style={editLink}>
               編集
             </Text>
           ),
@@ -573,12 +567,7 @@ export default function ItemDetailScreen() {
             <Kv k="着用回数" v={`${loaded.wearCount} 回`} />
             <Kv k="最終着用" v={formatDate(loaded.lastWornAt)} />
             <Kv k="Cost / Wear" v={formatCostPerWear(cpw)} />
-            {isSold && (
-              <Kv
-                k="Net / Wear"
-                v={formatCostPerWear(netCpw)}
-              />
-            )}
+            {isSold && <Kv k="Net / Wear" v={formatCostPerWear(netCpw)} />}
             {loaded.wearCount === 0 && isOwned && (
               <Text style={[muted, { marginTop: space.sm }]}>未着用です</Text>
             )}
@@ -643,16 +632,12 @@ export default function ItemDetailScreen() {
               <View style={{ marginTop: space.sm }}>
                 <Kv k="売却日" v={formatDate(loaded.saleInfo.soldAt)} />
                 <Kv k="売却価格" v={formatYen(loaded.saleInfo.soldPrice)} />
-                {loaded.saleInfo.soldSource && (
-                  <Kv k="販売元" v={loaded.saleInfo.soldSource} />
-                )}
+                {loaded.saleInfo.soldSource && <Kv k="販売元" v={loaded.saleInfo.soldSource} />}
                 {loaded.saleInfo.notes && <Kv k="メモ" v={loaded.saleInfo.notes} />}
               </View>
             )}
             <View style={{ marginTop: space.md, gap: space.sm }}>
-              {isOwned && (
-                <Button label="Sold にする" onPress={() => setSaleModalOpen(true)} />
-              )}
+              {isOwned && <Button label="Sold にする" onPress={() => setSaleModalOpen(true)} />}
               {isSold && (
                 <>
                   <Button

--- a/packages/app/app/settings/brand-guides/[id].tsx
+++ b/packages/app/app/settings/brand-guides/[id].tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import {
-  ActivityIndicator,
-  Alert,
-  ScrollView,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native';
+import { ActivityIndicator, Alert, ScrollView, Text, View, type ViewStyle } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import {
   CATEGORY_LABEL,
@@ -20,9 +13,10 @@ import { TextField } from '../../../src/components/TextField';
 import { brandGuideRepository } from '../../../src/repositories';
 import { colors, font, space } from '../../../src/theme';
 
-const CATEGORY_OPTIONS: ReadonlyArray<PickerOption<GarmentCategory>> = GARMENT_CATEGORIES.map(
-  (c) => ({ value: c, label: CATEGORY_LABEL[c] }),
-);
+const CATEGORY_OPTIONS: readonly PickerOption<GarmentCategory>[] = GARMENT_CATEGORIES.map((c) => ({
+  value: c,
+  label: CATEGORY_LABEL[c],
+}));
 
 export default function BrandGuideEditScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();

--- a/packages/app/app/settings/brand-guides/index.tsx
+++ b/packages/app/app/settings/brand-guides/index.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View, type ViewStyle } from 'react-native';
 import { Stack, router, useFocusEffect } from 'expo-router';
 import {
   CATEGORY_LABEL,
@@ -20,9 +13,10 @@ import { TextField } from '../../../src/components/TextField';
 import { brandGuideRepository } from '../../../src/repositories';
 import { colors, font, radii, space } from '../../../src/theme';
 
-const CATEGORY_OPTIONS: ReadonlyArray<PickerOption<GarmentCategory>> = GARMENT_CATEGORIES.map(
-  (c) => ({ value: c, label: CATEGORY_LABEL[c] }),
-);
+const CATEGORY_OPTIONS: readonly PickerOption<GarmentCategory>[] = GARMENT_CATEGORIES.map((c) => ({
+  value: c,
+  label: CATEGORY_LABEL[c],
+}));
 
 export default function BrandGuidesScreen() {
   const [guides, setGuides] = useState<BrandGuide[]>([]);
@@ -170,17 +164,12 @@ export default function BrandGuidesScreen() {
                 <Pressable
                   accessibilityRole="button"
                   onPress={() => router.push(`/settings/brand-guides/${g.id}`)}
-                  style={({ pressed }) => [
-                    { flex: 1 },
-                    pressed && { opacity: 0.6 },
-                  ]}
+                  style={({ pressed }) => [{ flex: 1 }, pressed && { opacity: 0.6 }]}
                 >
                   <Text style={guideTitle}>
                     {g.brand} · {g.title}
                   </Text>
-                  {g.category && (
-                    <Text style={guideSub}>{CATEGORY_LABEL[g.category]}</Text>
-                  )}
+                  {g.category && <Text style={guideSub}>{CATEGORY_LABEL[g.category]}</Text>}
                   {g.notes && (
                     <Text style={guideNotes} numberOfLines={2}>
                       {g.notes}

--- a/packages/app/app/settings/data-reset.tsx
+++ b/packages/app/app/settings/data-reset.tsx
@@ -22,19 +22,15 @@ export default function DataResetScreen() {
               setBusy(true);
               try {
                 await resetAllData();
-                Alert.alert(
-                  '削除しました',
-                  'アプリを完全に再起動することをおすすめします。',
-                  [
-                    {
-                      text: 'OK',
-                      onPress: () => {
-                        if (router.canGoBack()) router.back();
-                        else router.replace('/(tabs)/settings');
-                      },
+                Alert.alert('削除しました', 'アプリを完全に再起動することをおすすめします。', [
+                  {
+                    text: 'OK',
+                    onPress: () => {
+                      if (router.canGoBack()) router.back();
+                      else router.replace('/(tabs)/settings');
                     },
-                  ],
-                );
+                  },
+                ]);
               } catch (err) {
                 Alert.alert('削除失敗', err instanceof Error ? err.message : String(err));
               } finally {
@@ -66,11 +62,7 @@ export default function DataResetScreen() {
           <Text style={listItem}>• 通知リマインダー</Text>
         </View>
 
-        <Button
-          label={busy ? '削除中…' : 'すべて削除する'}
-          onPress={onConfirm}
-          loading={busy}
-        />
+        <Button label={busy ? '削除中…' : 'すべて削除する'} onPress={onConfirm} loading={busy} />
         <Button
           label="キャンセル"
           onPress={() => {

--- a/packages/app/app/settings/measurement-rules.tsx
+++ b/packages/app/app/settings/measurement-rules.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View, type ViewStyle } from 'react-native';
 import { Stack, useFocusEffect } from 'expo-router';
 import {
   CATEGORY_LABEL,
@@ -26,27 +19,26 @@ import { colors, font, radii, space } from '../../src/theme';
 type Operator = MeasurementRule['operator'];
 type Severity = MeasurementRule['severity'];
 
-const OPERATOR_OPTIONS: ReadonlyArray<PickerOption<Operator>> = [
+const OPERATOR_OPTIONS: readonly PickerOption<Operator>[] = [
   { value: 'lt', label: '<' },
   { value: 'lte', label: '≤' },
   { value: 'gt', label: '>' },
   { value: 'gte', label: '≥' },
 ];
 
-const SEVERITY_OPTIONS: ReadonlyArray<PickerOption<Severity>> = [
+const SEVERITY_OPTIONS: readonly PickerOption<Severity>[] = [
   { value: 'warning', label: 'Warning' },
   { value: 'ng', label: 'NG' },
 ];
 
-const CATEGORY_OPTIONS: ReadonlyArray<PickerOption<GarmentCategory>> = GARMENT_CATEGORIES.map(
-  (c) => ({ value: c, label: CATEGORY_LABEL[c] }),
-);
+const CATEGORY_OPTIONS: readonly PickerOption<GarmentCategory>[] = GARMENT_CATEGORIES.map((c) => ({
+  value: c,
+  label: CATEGORY_LABEL[c],
+}));
 
-const opLabel = (op: Operator): string =>
-  OPERATOR_OPTIONS.find((o) => o.value === op)?.label ?? op;
+const opLabel = (op: Operator): string => OPERATOR_OPTIONS.find((o) => o.value === op)?.label ?? op;
 
-const sevLabel = (s: Severity): string =>
-  SEVERITY_OPTIONS.find((o) => o.value === s)?.label ?? s;
+const sevLabel = (s: Severity): string => SEVERITY_OPTIONS.find((o) => o.value === s)?.label ?? s;
 
 export default function MeasurementRulesScreen() {
   const [rules, setRules] = useState<MeasurementRule[]>([]);
@@ -76,7 +68,7 @@ export default function MeasurementRulesScreen() {
     }, [load]),
   );
 
-  const measurementKeyOptions = useMemo<ReadonlyArray<PickerOption<MeasurementKey>>>(() => {
+  const measurementKeyOptions = useMemo<readonly PickerOption<MeasurementKey>[]>(() => {
     if (!category) return [];
     return measurementKeysFor(category).map((k) => ({
       value: k,
@@ -128,23 +120,27 @@ export default function MeasurementRulesScreen() {
 
   const onDelete = useCallback(
     (rule: MeasurementRule) => {
-      Alert.alert('削除しますか？', `${MEASUREMENT_KEY_LABEL[rule.measurementKey]} のルールを削除します。`, [
-        { text: 'キャンセル', style: 'cancel' },
-        {
-          text: '削除',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              try {
-                await measurementRuleRepository.delete(rule.id);
-                await load();
-              } catch (err) {
-                Alert.alert('削除失敗', err instanceof Error ? err.message : String(err));
-              }
-            })();
+      Alert.alert(
+        '削除しますか？',
+        `${MEASUREMENT_KEY_LABEL[rule.measurementKey]} のルールを削除します。`,
+        [
+          { text: 'キャンセル', style: 'cancel' },
+          {
+            text: '削除',
+            style: 'destructive',
+            onPress: () => {
+              void (async () => {
+                try {
+                  await measurementRuleRepository.delete(rule.id);
+                  await load();
+                } catch (err) {
+                  Alert.alert('削除失敗', err instanceof Error ? err.message : String(err));
+                }
+              })();
+            },
           },
-        },
-      ]);
+        ],
+      );
     },
     [load],
   );

--- a/packages/app/babel.config.js
+++ b/packages/app/babel.config.js
@@ -2,9 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'react' }]],
-    plugins: [
-      ['inline-import', { extensions: ['.sql'] }],
-      'react-native-reanimated/plugin',
-    ],
+    plugins: [['inline-import', { extensions: ['.sql'] }], 'react-native-reanimated/plugin'],
   };
 };

--- a/packages/app/eslint.config.js
+++ b/packages/app/eslint.config.js
@@ -1,0 +1,8 @@
+const expoConfig = require('eslint-config-expo/flat');
+
+module.exports = [
+  ...expoConfig,
+  {
+    ignores: ['.expo/', 'dist/', 'node_modules/', 'src/db/migrations/', 'ios/', 'android/'],
+  },
+];

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,11 +6,9 @@
   "scripts": {
     "start": "expo start",
     "ios": "expo run:ios",
-    "android": "expo run:android",
-    "web": "expo start --web",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:check": "drizzle-kit check",
     "prebuild": "node scripts/prebuild.mjs",
@@ -19,13 +17,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
-    "@expo/metro-runtime": "~6.1.2",
     "@hookform/resolvers": "^3.9.1",
     "@paralleldrive/cuid2": "^2.2.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@seam/domain": "workspace:*",
     "@seam/shared": "workspace:*",
-    "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.0",
     "expo": "~54.0.33",
     "expo-application": "~7.0.8",
@@ -42,21 +38,21 @@
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
     "react-hook-form": "^7.54.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.7",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "~4.16.0",
-    "zod": "^3.23.8",
-    "zustand": "^5.0.2"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",
     "@types/react": "19.1.17",
     "babel-plugin-inline-import": "3.0.0",
     "drizzle-kit": "0.31.10",
+    "eslint": "^9.39.4",
+    "eslint-config-expo": "^55.0.0",
     "typescript": "5.9.3",
     "vitest": "2.1.9"
   }

--- a/packages/app/scripts/packageIpa.mjs
+++ b/packages/app/scripts/packageIpa.mjs
@@ -1,12 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  rmSync,
-  statSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -32,9 +25,7 @@ function findLatestArchive() {
     }
   }
   if (candidates.length === 0) {
-    throw new Error(
-      `No ${APP_NAME} .xcarchive found. Run Product > Archive in Xcode first.`,
-    );
+    throw new Error(`No ${APP_NAME} .xcarchive found. Run Product > Archive in Xcode first.`);
   }
   candidates.sort((a, b) => b.mtime - a.mtime);
   return candidates[0].path;
@@ -67,15 +58,11 @@ if (existsSync(ipaPath)) {
   console.log(`[packageIpa] removed existing ${ipaPath}`);
 }
 
-const zip = spawnSync(
-  'ditto',
-  ['-c', '-k', '--keepParent', '--norsrc', 'Payload', ipaPath],
-  {
-    cwd: work,
-    stdio: 'inherit',
-    env: { ...process.env, COPYFILE_DISABLE: '1' },
-  },
-);
+const zip = spawnSync('ditto', ['-c', '-k', '--keepParent', '--norsrc', 'Payload', ipaPath], {
+  cwd: work,
+  stdio: 'inherit',
+  env: { ...process.env, COPYFILE_DISABLE: '1' },
+});
 if (zip.status !== 0) {
   throw new Error(`ditto exited with status ${zip.status}`);
 }

--- a/packages/app/scripts/stripPushEntitlement.mjs
+++ b/packages/app/scripts/stripPushEntitlement.mjs
@@ -12,10 +12,7 @@ if (!existsSync(entitlementsPath)) {
 }
 
 const before = await readFile(entitlementsPath, 'utf8');
-const after = before.replace(
-  /\s*<key>aps-environment<\/key>\s*<string>[^<]*<\/string>/g,
-  '',
-);
+const after = before.replace(/\s*<key>aps-environment<\/key>\s*<string>[^<]*<\/string>/g, '');
 
 if (before === after) {
   console.log('[stripPushEntitlement] aps-environment not present, nothing to do');

--- a/packages/app/src/backup/jsonImport.ts
+++ b/packages/app/src/backup/jsonImport.ts
@@ -116,10 +116,10 @@ export const truncateAllTables = async (): Promise<void> => {
     const tableName = IMPORT_ORDER[i];
     if (!tableName) continue;
     const handle = TABLE_HANDLES[tableName];
-    // eslint-disable-next-line no-await-in-loop -- sequential ordering matters for FKs
+
     await db.delete(handle.table as never);
   }
-}
+};
 
 const buildPkSet = async (tableName: TableName): Promise<Set<string>> => {
   const handle = TABLE_HANDLES[tableName];
@@ -166,11 +166,11 @@ export const importFromJsonFile = async (
 
     let toInsert: Record<string, unknown>[];
     if (opts.mode === 'merge') {
-      // eslint-disable-next-line no-await-in-loop -- per-table dependency ordering
       const existing = await buildPkSet(tableName);
-      toInsert = incoming.filter(
-        (row) => !existing.has(rowKey(row, handle.pk)),
-      ) as Record<string, unknown>[];
+      toInsert = incoming.filter((row) => !existing.has(rowKey(row, handle.pk))) as Record<
+        string,
+        unknown
+      >[];
     } else {
       toInsert = incoming as Record<string, unknown>[];
     }
@@ -186,7 +186,7 @@ export const importFromJsonFile = async (
       const CHUNK = 50;
       for (let i = 0; i < toInsert.length; i += CHUNK) {
         const chunk = toInsert.slice(i, i + CHUNK);
-        // eslint-disable-next-line no-await-in-loop -- chunked sequential inserts
+
         await db.insert(handle.table as never).values(chunk as never);
       }
       insertedCounts[tableName] = toInsert.length;

--- a/packages/app/src/components/Chip.tsx
+++ b/packages/app/src/components/Chip.tsx
@@ -12,7 +12,14 @@ type Props = {
   style?: StyleProp<ViewStyle>;
 };
 
-export const Chip = ({ label, tone = 'default', selected = false, onPress, onRemove, style }: Props) => {
+export const Chip = ({
+  label,
+  tone = 'default',
+  selected = false,
+  onPress,
+  onRemove,
+  style,
+}: Props) => {
   const palette = tonePalette[selected ? 'inverse' : tone];
   const content = (
     <View style={[base, { backgroundColor: palette.bg, borderColor: palette.border }, style]}>

--- a/packages/app/src/components/DecisionReasonModal.tsx
+++ b/packages/app/src/components/DecisionReasonModal.tsx
@@ -49,12 +49,7 @@ export const DecisionReasonModal = ({
   if (!decision) return null;
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onCancel}
-    >
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={overlay}

--- a/packages/app/src/components/FailureLogModal.tsx
+++ b/packages/app/src/components/FailureLogModal.tsx
@@ -27,14 +27,14 @@ type Props = {
   onSubmit: (draft: FailureLogDraft) => void;
 };
 
-const RESULT_OPTIONS: ReadonlyArray<PickerOption<FailureLog['result']>> = [
+const RESULT_OPTIONS: readonly PickerOption<FailureLog['result']>[] = [
   { value: 'success', label: '成功' },
   { value: 'mixed', label: '一部成功' },
   { value: 'failure', label: '失敗' },
 ];
 
-const REASON_OPTIONS: ReadonlyArray<PickerOption<FailureReason>> = (
-  Object.entries(FAILURE_REASON_LABEL) as Array<[FailureReason, string]>
+const REASON_OPTIONS: readonly PickerOption<FailureReason>[] = (
+  Object.entries(FAILURE_REASON_LABEL) as [FailureReason, string][]
 ).map(([value, label]) => ({ value, label }));
 
 export const FailureLogModal = ({ visible, submitting, onCancel, onSubmit }: Props) => {

--- a/packages/app/src/components/ItemCard.tsx
+++ b/packages/app/src/components/ItemCard.tsx
@@ -16,8 +16,7 @@ export const ItemCard = ({ item, thumbnailRelativePath, wearCount, onPress }: Pr
   const subtitleParts = [item.brand, item.sizeLabel, CATEGORY_LABEL[item.category]].filter(
     (p): p is string => Boolean(p),
   );
-  const isUnworn =
-    item.status === 'owned' && wearCount !== undefined && wearCount === 0;
+  const isUnworn = item.status === 'owned' && wearCount !== undefined && wearCount === 0;
   const content = (
     <View style={card}>
       <View style={thumbBox}>
@@ -61,11 +60,7 @@ export const ItemCard = ({ item, thumbnailRelativePath, wearCount, onPress }: Pr
     </View>
   );
   if (onPress) {
-    const labelParts = [
-      item.name,
-      ...subtitleParts,
-      ITEM_STATUS_LABEL[item.status],
-    ];
+    const labelParts = [item.name, ...subtitleParts, ITEM_STATUS_LABEL[item.status]];
     return (
       <Pressable
         accessibilityRole="button"

--- a/packages/app/src/components/MeasurementExtractionReviewModal.tsx
+++ b/packages/app/src/components/MeasurementExtractionReviewModal.tsx
@@ -9,11 +9,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
-import {
-  MEASUREMENT_KEY_LABEL,
-  type GarmentCategory,
-  type MeasurementKey,
-} from '@seam/shared';
+import { MEASUREMENT_KEY_LABEL, type GarmentCategory, type MeasurementKey } from '@seam/shared';
 import {
   extractMeasurementsFromText,
   type ExtractedMeasurement,
@@ -86,12 +82,7 @@ export const MeasurementExtractionReviewModal = ({
   };
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onCancel}
-    >
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={overlay}
@@ -115,16 +106,10 @@ export const MeasurementExtractionReviewModal = ({
                 <View style={summaryRow}>
                   <Text style={summaryLabel}>信頼度</Text>
                   <View
-                    style={[
-                      confidenceBadge,
-                      { borderColor: CONFIDENCE_TONE[result.confidence] },
-                    ]}
+                    style={[confidenceBadge, { borderColor: CONFIDENCE_TONE[result.confidence] }]}
                   >
                     <Text
-                      style={[
-                        confidenceBadgeText,
-                        { color: CONFIDENCE_TONE[result.confidence] },
-                      ]}
+                      style={[confidenceBadgeText, { color: CONFIDENCE_TONE[result.confidence] }]}
                     >
                       {CONFIDENCE_LABEL[result.confidence]}
                     </Text>
@@ -143,10 +128,7 @@ export const MeasurementExtractionReviewModal = ({
                           accessibilityRole="checkbox"
                           accessibilityState={{ checked }}
                           onPress={() => toggleAdopt(m.key)}
-                          style={({ pressed }) => [
-                            measurementRow,
-                            pressed && { opacity: 0.6 },
-                          ]}
+                          style={({ pressed }) => [measurementRow, pressed && { opacity: 0.6 }]}
                         >
                           <View style={[checkbox, checked && checkboxChecked]}>
                             {checked && <Text style={checkmark}>✓</Text>}
@@ -164,7 +146,8 @@ export const MeasurementExtractionReviewModal = ({
                 {result.unmatchedKeys.length > 0 && (
                   <View style={{ marginTop: space.sm }}>
                     <Text style={muted}>
-                      範囲外として除外: {result.unmatchedKeys
+                      範囲外として除外:{' '}
+                      {result.unmatchedKeys
                         .map((k) => MEASUREMENT_KEY_LABEL[k as MeasurementKey] ?? k)
                         .join(', ')}
                     </Text>

--- a/packages/app/src/components/PhotoPicker.tsx
+++ b/packages/app/src/components/PhotoPicker.tsx
@@ -48,7 +48,6 @@ export const PhotoPicker = ({ photos, onChange, max = 8 }: Props) => {
       if (result.canceled) return;
       const saved: SavedPhoto[] = [];
       for (const asset of result.assets) {
-        // eslint-disable-next-line no-await-in-loop -- intentional sequential save
         const s = await savePhoto(asset.uri);
         saved.push(s);
       }

--- a/packages/app/src/components/Picker.tsx
+++ b/packages/app/src/components/Picker.tsx
@@ -19,7 +19,7 @@ export type PickerOption<T extends string> = {
 type Props<T extends string> = {
   label?: string;
   value: T | undefined;
-  options: ReadonlyArray<PickerOption<T>>;
+  options: readonly PickerOption<T>[];
   onChange: (value: T) => void;
   placeholder?: string;
   error?: string;

--- a/packages/app/src/components/ReminderSettingsModal.tsx
+++ b/packages/app/src/components/ReminderSettingsModal.tsx
@@ -9,11 +9,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
-import {
-  ALL_LEAD_TIMES,
-  leadTimeLabel,
-  type ReminderLeadTime,
-} from '../notifications';
+import { ALL_LEAD_TIMES, leadTimeLabel, type ReminderLeadTime } from '../notifications';
 import { Button } from './Button';
 import { colors, font, radii, space } from '../theme';
 
@@ -48,9 +44,7 @@ export const ReminderSettingsModal = ({
   onSubmit,
 }: Props) => {
   const [enabled, setEnabled] = useState<boolean>(initial.enabled);
-  const [selected, setSelected] = useState<Set<ReminderLeadTime>>(
-    () => new Set(initial.leadTimes),
-  );
+  const [selected, setSelected] = useState<Set<ReminderLeadTime>>(() => new Set(initial.leadTimes));
 
   useEffect(() => {
     if (visible) {
@@ -84,11 +78,7 @@ export const ReminderSettingsModal = ({
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={overlay}
       >
-        <Pressable
-          style={backdrop}
-          onPress={onCancel}
-          accessibilityLabel="閉じる"
-        />
+        <Pressable style={backdrop} onPress={onCancel} accessibilityLabel="閉じる" />
         <View style={card} accessibilityViewIsModal>
           <Text style={title}>終了通知設定</Text>
           <Text style={muted}>終了日時: {formatEnd(auctionEndsAt)}</Text>
@@ -102,9 +92,7 @@ export const ReminderSettingsModal = ({
             />
           </View>
 
-          <Text style={[muted, { marginTop: space.md }]}>
-            終了の何分前に通知を受け取りますか？
-          </Text>
+          <Text style={[muted, { marginTop: space.md }]}>終了の何分前に通知を受け取りますか？</Text>
           <View style={chipWrap}>
             {ALL_LEAD_TIMES.map((lt) => {
               const isOn = selected.has(lt);

--- a/packages/app/src/components/SaleInfoModal.tsx
+++ b/packages/app/src/components/SaleInfoModal.tsx
@@ -45,13 +45,7 @@ const parsePriceInput = (raw: string): number | undefined => {
   return Number.isFinite(n) && n >= 0 ? Math.round(n) : undefined;
 };
 
-export const SaleInfoModal = ({
-  visible,
-  submitting,
-  initial,
-  onCancel,
-  onSubmit,
-}: Props) => {
+export const SaleInfoModal = ({ visible, submitting, initial, onCancel, onSubmit }: Props) => {
   const [soldPrice, setSoldPrice] = useState('');
   const [soldAt, setSoldAt] = useState('');
   const [soldSource, setSoldSource] = useState('');
@@ -81,8 +75,7 @@ export const SaleInfoModal = ({
     const trimmedNotes = notes.trim();
     onSubmit({
       soldPrice: parsePriceInput(soldPrice),
-      soldAt:
-        soldAt.trim() === '' ? undefined : new Date(soldAt).toISOString(),
+      soldAt: soldAt.trim() === '' ? undefined : new Date(soldAt).toISOString(),
       soldSource: trimmedSource === '' ? undefined : trimmedSource,
       notes: trimmedNotes === '' ? undefined : trimmedNotes,
     });

--- a/packages/app/src/components/ScoreBreakdown.tsx
+++ b/packages/app/src/components/ScoreBreakdown.tsx
@@ -82,9 +82,7 @@ export const ScoreBreakdown = ({ breakdown, style }: Props) => {
 };
 
 /** Pull a CandidateEvaluation row into the shape ScoreBreakdown expects. */
-export const breakdownFromEvaluation = (
-  ev: CandidateEvaluation,
-): Props['breakdown'] => ({
+export const breakdownFromEvaluation = (ev: CandidateEvaluation): Props['breakdown'] => ({
   sizeScore: ev.sizeScore,
   priceScore: ev.priceScore,
   conditionScore: ev.conditionScore,

--- a/packages/app/src/components/StatCard.tsx
+++ b/packages/app/src/components/StatCard.tsx
@@ -14,8 +14,7 @@ type Props = {
 };
 
 export const StatCard = ({ title, value, subtext, tone = 'default', style }: Props) => {
-  const accent =
-    tone === 'warning' ? colors.warning : tone === 'good' ? colors.same : colors.text;
+  const accent = tone === 'warning' ? colors.warning : tone === 'good' ? colors.same : colors.text;
   return (
     <View style={[card, { borderColor: tone === 'default' ? colors.border : accent }, style]}>
       <Text style={[titleStyle, { color: tone === 'default' ? colors.textMuted : accent }]}>

--- a/packages/app/src/forms/ItemForm.tsx
+++ b/packages/app/src/forms/ItemForm.tsx
@@ -36,9 +36,10 @@ const isFavoriteScore = (n: number): n is FavoriteScore =>
 
 // Status options exposed to the picker — `sold` is reserved for Phase 6
 // (post-purchase flow), so we omit it from the form input.
-const SELECTABLE_STATUSES = ITEM_STATUSES.filter((s) => s !== 'sold') as ReadonlyArray<
-  Exclude<ItemStatus, 'sold'>
->;
+const SELECTABLE_STATUSES = ITEM_STATUSES.filter((s) => s !== 'sold') as readonly Exclude<
+  ItemStatus,
+  'sold'
+>[];
 const CANDIDATE_STATUS_SET = new Set<ItemStatus>([
   'wishlist',
   'watching',
@@ -56,15 +57,8 @@ const FormSchema = z.object({
   sizeLabel: z.string().trim().optional(),
   conditionRank: z.enum(CONDITION_RANKS as readonly [ConditionRank, ...ConditionRank[]]).optional(),
   conditionNotes: z.string().trim().optional(),
-  fitRating: z
-    .enum(['too_small', 'just', 'slightly_large', 'large', 'too_large'])
-    .optional(),
-  favoriteScore: z
-    .number()
-    .int()
-    .min(1)
-    .max(5)
-    .optional(),
+  fitRating: z.enum(['too_small', 'just', 'slightly_large', 'large', 'too_large']).optional(),
+  favoriteScore: z.number().int().min(1).max(5).optional(),
   purchasePrice: z.string().trim().optional(),
   shippingFee: z.string().trim().optional(),
   purchaseDate: z.string().trim().optional(),
@@ -126,23 +120,22 @@ type Props = {
 
 const PLACEHOLDER_ITEM_ID = 'pending';
 
-const STATUS_OPTIONS: ReadonlyArray<PickerOption<ItemStatus>> = SELECTABLE_STATUSES.map((s) => ({
+const STATUS_OPTIONS: readonly PickerOption<ItemStatus>[] = SELECTABLE_STATUSES.map((s) => ({
   value: s,
   label: ITEM_STATUS_LABEL[s],
 }));
 
-const CATEGORY_OPTIONS: ReadonlyArray<PickerOption<GarmentCategory>> = GARMENT_CATEGORIES.map(
-  (c) => ({ value: c, label: CATEGORY_LABEL[c] }),
-);
+const CATEGORY_OPTIONS: readonly PickerOption<GarmentCategory>[] = GARMENT_CATEGORIES.map((c) => ({
+  value: c,
+  label: CATEGORY_LABEL[c],
+}));
 
-const CONDITION_OPTIONS: ReadonlyArray<PickerOption<ConditionRank>> = CONDITION_RANKS.map((r) => ({
+const CONDITION_OPTIONS: readonly PickerOption<ConditionRank>[] = CONDITION_RANKS.map((r) => ({
   value: r,
   label: r,
 }));
 
-const FIT_RATING_OPTIONS: ReadonlyArray<
-  PickerOption<NonNullable<ItemFormValues['fitRating']>>
-> = [
+const FIT_RATING_OPTIONS: readonly PickerOption<NonNullable<ItemFormValues['fitRating']>>[] = [
   { value: 'too_small', label: '小さすぎ' },
   { value: 'just', label: 'ジャスト' },
   { value: 'slightly_large', label: '少し大きい' },
@@ -150,11 +143,12 @@ const FIT_RATING_OPTIONS: ReadonlyArray<
   { value: 'too_large', label: '大きすぎ' },
 ];
 
-const FAVORITE_SCORE_OPTIONS: ReadonlyArray<PickerOption<string>> = FAVORITE_SCORE_VALUES.map(
-  (n) => ({ value: String(n), label: '★'.repeat(n) }),
-);
+const FAVORITE_SCORE_OPTIONS: readonly PickerOption<string>[] = FAVORITE_SCORE_VALUES.map((n) => ({
+  value: String(n),
+  label: '★'.repeat(n),
+}));
 
-const SOURCE_TYPE_OPTIONS: ReadonlyArray<PickerOption<SourceType>> = SOURCE_TYPES.map((s) => ({
+const SOURCE_TYPE_OPTIONS: readonly PickerOption<SourceType>[] = SOURCE_TYPES.map((s) => ({
   value: s,
   label: SOURCE_TYPE_LABEL[s],
 }));

--- a/packages/app/src/notifications/notificationManager.ts
+++ b/packages/app/src/notifications/notificationManager.ts
@@ -20,13 +20,7 @@ const LEAD_TIME_LABEL_JA: Record<ReminderLeadTime, string> = {
   '1d': '1日前',
 };
 
-export const ALL_LEAD_TIMES: readonly ReminderLeadTime[] = [
-  '10m',
-  '30m',
-  '1h',
-  '3h',
-  '1d',
-];
+export const ALL_LEAD_TIMES: readonly ReminderLeadTime[] = ['10m', '30m', '1h', '3h', '1d'];
 
 export const leadTimeLabel = (lt: ReminderLeadTime): string => LEAD_TIME_LABEL_JA[lt];
 
@@ -102,7 +96,7 @@ export const scheduleAuctionReminders = async (
   for (const lt of opts.leadTimes) {
     const triggerMs = endMs - LEAD_TIME_MS[lt];
     if (triggerMs <= now) continue; // skip past lead times
-    // eslint-disable-next-line no-await-in-loop -- sequential to keep ordering deterministic
+
     const id = await Notifications.scheduleNotificationAsync({
       content: {
         title: `終了まで${LEAD_TIME_LABEL_JA[lt]}: ${opts.itemName}`,
@@ -126,7 +120,6 @@ export const scheduleAuctionReminders = async (
 /** Cancel one or more previously-scheduled reminders by their identifier. */
 export const cancelReminders = async (notificationIds: readonly string[]): Promise<void> => {
   for (const id of notificationIds) {
-    // eslint-disable-next-line no-await-in-loop -- sequential keeps API simple
     await Notifications.cancelScheduledNotificationAsync(id);
   }
 };

--- a/packages/app/src/repositories/brandChecklistStateRepository.ts
+++ b/packages/app/src/repositories/brandChecklistStateRepository.ts
@@ -23,10 +23,7 @@ type ToggleInput = {
 };
 
 export const brandChecklistStateRepository = {
-  async listForItemAndGuide(
-    itemId: string,
-    brandGuideId: string,
-  ): Promise<BrandChecklistState[]> {
+  async listForItemAndGuide(itemId: string, brandGuideId: string): Promise<BrandChecklistState[]> {
     const rows = await db
       .select()
       .from(schema.brandChecklistStates)

--- a/packages/app/src/repositories/failureLogRepository.ts
+++ b/packages/app/src/repositories/failureLogRepository.ts
@@ -77,9 +77,7 @@ export const failureLogRepository = {
   },
 
   async countAll(): Promise<number> {
-    const rows = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(schema.failureLogs);
+    const rows = await db.select({ count: sql<number>`count(*)` }).from(schema.failureLogs);
     return Number(rows[0]?.count ?? 0);
   },
 

--- a/packages/app/src/repositories/fitAnchorRepository.ts
+++ b/packages/app/src/repositories/fitAnchorRepository.ts
@@ -2,8 +2,7 @@ import { eq } from 'drizzle-orm';
 import { db, schema } from '../db/client';
 import { newId } from '../utils/ids';
 import { nowIso } from '../utils/dates';
-import type { FitAnchor } from '@seam/shared';
-import type { GarmentCategory } from '@seam/shared';
+import type { FitAnchor, GarmentCategory } from '@seam/shared';
 
 const toAnchor = (row: typeof schema.fitAnchors.$inferSelect): FitAnchor => ({
   id: row.id,

--- a/packages/app/src/repositories/itemFlow.ts
+++ b/packages/app/src/repositories/itemFlow.ts
@@ -43,7 +43,7 @@ export const createItemWithDetails = async (
   for (let i = 0; i < input.photos.length; i += 1) {
     const p = input.photos[i];
     if (!p) continue;
-    // eslint-disable-next-line no-await-in-loop -- sequential to keep sortOrder stable
+
     await photoRepository.create(created.id, p.relativePath, p.thumbnailRelativePath, i);
   }
 
@@ -136,7 +136,6 @@ export const deleteItemWithDetails = async (id: string): Promise<void> => {
   await itemRepository.delete(id);
   for (const p of photos) {
     try {
-      // eslint-disable-next-line no-await-in-loop -- best-effort cleanup
       await deletePhotoFiles(p.relativePath, p.thumbnailRelativePath);
     } catch {
       // ignore

--- a/packages/app/src/repositories/itemRepository.ts
+++ b/packages/app/src/repositories/itemRepository.ts
@@ -2,8 +2,7 @@ import { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
 import { db, schema } from '../db/client';
 import { newId } from '../utils/ids';
 import { nowIso } from '../utils/dates';
-import type { GarmentItem } from '@seam/shared';
-import type { ItemStatus } from '@seam/shared';
+import type { GarmentItem, ItemStatus } from '@seam/shared';
 import { CANDIDATE_STATUSES } from '@seam/shared';
 
 export type ItemRow = typeof schema.items.$inferSelect;
@@ -95,11 +94,7 @@ export const itemRepository = {
       );
     }
     const where = conditions.length > 0 ? and(...conditions) : undefined;
-    const rows = await db
-      .select()
-      .from(schema.items)
-      .where(where)
-      .orderBy(orderByFor(sort));
+    const rows = await db.select().from(schema.items).where(where).orderBy(orderByFor(sort));
     return rows.map(toGarmentItem);
   },
 

--- a/packages/app/src/repositories/measurementRepository.ts
+++ b/packages/app/src/repositories/measurementRepository.ts
@@ -1,8 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { db, schema } from '../db/client';
 import { newId } from '../utils/ids';
-import type { Measurement, MeasurementInput } from '@seam/shared';
-import type { MeasurementKey, MeasurementUnit } from '@seam/shared';
+import type { Measurement, MeasurementInput, MeasurementKey, MeasurementUnit } from '@seam/shared';
 
 const toMeasurement = (row: typeof schema.measurements.$inferSelect): Measurement => ({
   id: row.id,

--- a/packages/app/src/repositories/measurementRuleRepository.ts
+++ b/packages/app/src/repositories/measurementRuleRepository.ts
@@ -2,11 +2,7 @@ import { and, asc, eq } from 'drizzle-orm';
 import { db, schema } from '../db/client';
 import { newId } from '../utils/ids';
 import { nowIso } from '../utils/dates';
-import type {
-  GarmentCategory,
-  MeasurementKey,
-  MeasurementRule,
-} from '@seam/shared';
+import type { GarmentCategory, MeasurementKey, MeasurementRule } from '@seam/shared';
 
 type Row = typeof schema.measurementRules.$inferSelect;
 

--- a/packages/app/src/repositories/photoRepository.ts
+++ b/packages/app/src/repositories/photoRepository.ts
@@ -53,11 +53,8 @@ export const photoRepository = {
     for (let i = 0; i < orderedIds.length; i += 1) {
       const id = orderedIds[i];
       if (!id) continue;
-      // eslint-disable-next-line no-await-in-loop -- sequential to keep semantics simple
-      await db
-        .update(schema.photos)
-        .set({ sortOrder: i })
-        .where(eq(schema.photos.id, id));
+
+      await db.update(schema.photos).set({ sortOrder: i }).where(eq(schema.photos.id, id));
     }
     void itemId;
   },

--- a/packages/app/src/repositories/saleInfoRepository.ts
+++ b/packages/app/src/repositories/saleInfoRepository.ts
@@ -39,10 +39,7 @@ export const saleInfoRepository = {
       .where(eq(schema.saleInfos.itemId, info.itemId))
       .limit(1);
     if (existing.length > 0) {
-      await db
-        .update(schema.saleInfos)
-        .set(row)
-        .where(eq(schema.saleInfos.itemId, info.itemId));
+      await db.update(schema.saleInfos).set(row).where(eq(schema.saleInfos.itemId, info.itemId));
     } else {
       await db.insert(schema.saleInfos).values(row);
     }

--- a/packages/app/src/repositories/tagRepository.ts
+++ b/packages/app/src/repositories/tagRepository.ts
@@ -38,9 +38,7 @@ export const tagRepository = {
     const tags = await Promise.all(tagNames.map((n) => this.ensure(n)));
     await db.delete(schema.itemTags).where(eq(schema.itemTags.itemId, itemId));
     if (tags.length > 0) {
-      await db
-        .insert(schema.itemTags)
-        .values(tags.map((t) => ({ itemId, tagId: t.id })));
+      await db.insert(schema.itemTags).values(tags.map((t) => ({ itemId, tagId: t.id })));
     }
   },
 

--- a/packages/app/src/repositories/wearLogRepository.ts
+++ b/packages/app/src/repositories/wearLogRepository.ts
@@ -69,9 +69,7 @@ export const wearLogRepository = {
    * Total wear-log count across the wardrobe. Used by the Stats screen.
    */
   async countAll(): Promise<number> {
-    const rows = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(schema.wearLogs);
+    const rows = await db.select({ count: sql<number>`count(*)` }).from(schema.wearLogs);
     return Number(rows[0]?.count ?? 0);
   },
 

--- a/packages/app/src/scoring/computeCandidateScore.ts
+++ b/packages/app/src/scoring/computeCandidateScore.ts
@@ -44,20 +44,18 @@ export const computeCandidateScore = async (
     throw new Error(`Item not found: ${itemId}`);
   }
 
-  const [candidateMeasurements, candidateInfo, anchorRows, ownedItems, rules] =
-    await Promise.all([
-      measurementRepository.listByItem(itemId),
-      candidateInfoRepository.getByItemId(itemId),
-      fitAnchorRepository.listByCategory(candidate.category),
-      itemRepository.listOwned(),
-      measurementRuleRepository.listByCategory(candidate.category),
-    ]);
+  const [candidateMeasurements, candidateInfo, anchorRows, ownedItems, rules] = await Promise.all([
+    measurementRepository.listByItem(itemId),
+    candidateInfoRepository.getByItemId(itemId),
+    fitAnchorRepository.listByCategory(candidate.category),
+    itemRepository.listOwned(),
+    measurementRuleRepository.listByCategory(candidate.category),
+  ]);
 
   // Hydrate anchors → SizeScoreAnchor[]
   const anchors: SizeScoreAnchor[] = [];
   const comparedAnchorIds: string[] = [];
   for (const a of anchorRows) {
-    // eslint-disable-next-line no-await-in-loop
     const [aItem, aMs] = await Promise.all([
       itemRepository.getById(a.itemId),
       measurementRepository.listByItem(a.itemId),

--- a/packages/app/src/stats/aggregateStats.ts
+++ b/packages/app/src/stats/aggregateStats.ts
@@ -37,20 +37,20 @@ export type StatsSnapshot = {
     sold: number;
     skipped: number;
   };
-  byCategory: Array<{ category: GarmentCategory; count: number; label: string }>;
-  byBrand: Array<{ brand: string; count: number }>;
-  byColor: Array<{ color: string; count: number }>;
-  monthlyPurchase: Array<{ month: string; count: number; amount: number }>;
+  byCategory: { category: GarmentCategory; count: number; label: string }[];
+  byBrand: { brand: string; count: number }[];
+  byColor: { color: string; count: number }[];
+  monthlyPurchase: { month: string; count: number; amount: number }[];
   avgPurchasePrice: number;
   recentBuyDecisions: number;
   recentSkipDecisions: number;
   recentWatchDecisions: number;
   decisionRatio: Record<DecisionKind, number>;
-  unworn: Array<{ id: string; name: string; daysSincePurchase: number }>;
-  sellCandidates: Array<{ id: string; name: string }>;
+  unworn: { id: string; name: string; daysSincePurchase: number }[];
+  sellCandidates: { id: string; name: string }[];
   duplicateClusters: DuplicateCluster[];
-  highCpwItems: Array<{ id: string; name: string; cpw: number; wearCount: number }>;
-  failureReasonRanking: Array<{ reason: FailureReason; label: string; count: number }>;
+  highCpwItems: { id: string; name: string; cpw: number; wearCount: number }[];
+  failureReasonRanking: { reason: FailureReason; label: string; count: number }[];
 };
 
 const inLastNDays = (iso: string, now: Date, days: number): boolean => {
@@ -144,7 +144,7 @@ export const aggregateStats = async (): Promise<StatsSnapshot> => {
 
   // CPW ranking (high CPW = bad value). Excludes items with 0 wears since
   // their CPW is undefined; "未着用" already covers that bucket above.
-  const cpwItems: Array<{ id: string; name: string; cpw: number; wearCount: number }> = [];
+  const cpwItems: { id: string; name: string; cpw: number; wearCount: number }[] = [];
   for (const it of owned) {
     const wears = wearCounts[it.id] ?? 0;
     if (wears === 0) continue;
@@ -155,7 +155,7 @@ export const aggregateStats = async (): Promise<StatsSnapshot> => {
   cpwItems.sort((a, b) => b.cpw - a.cpw);
   const highCpwItems = cpwItems.slice(0, TOP_N_RANKINGS);
 
-  const failureReasonRanking = (Object.entries(reasonCounts) as Array<[FailureReason, number]>)
+  const failureReasonRanking = (Object.entries(reasonCounts) as [FailureReason, number][])
     .filter(([, n]) => n > 0)
     .map(([reason, count]) => ({
       reason,

--- a/packages/app/src/stats/aggregators.test.ts
+++ b/packages/app/src/stats/aggregators.test.ts
@@ -174,9 +174,7 @@ describe('monthlyPurchaseBuckets', () => {
 
   it('ignores items outside the window', () => {
     const now = new Date(2026, 3, 26);
-    const items = [
-      baseItem({ id: 'old', purchaseDate: '2024-01-01', totalPrice: 9999 }),
-    ];
+    const items = [baseItem({ id: 'old', purchaseDate: '2024-01-01', totalPrice: 9999 })];
     const buckets = monthlyPurchaseBuckets(items, now, 3);
     expect(buckets.every((b) => b.amount === 0)).toBe(true);
   });

--- a/packages/app/src/stats/aggregators.ts
+++ b/packages/app/src/stats/aggregators.ts
@@ -106,7 +106,7 @@ export const topNCounts = <T>(
   items: readonly T[],
   pick: (item: T) => string | undefined | null,
   n: number,
-): Array<{ key: string; count: number }> => {
+): { key: string; count: number }[] => {
   const counts = new Map<string, number>();
   for (const it of items) {
     const raw = pick(it);
@@ -131,7 +131,7 @@ export const monthlyPurchaseBuckets = (
   items: readonly GarmentItem[],
   now: Date,
   months: number,
-): Array<{ month: string; count: number; amount: number }> => {
+): { month: string; count: number; amount: number }[] => {
   const buckets = new Map<string, { count: number; amount: number }>();
   for (const m of lastNMonths(now, months)) {
     buckets.set(m, { count: 0, amount: 0 });

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -15,11 +15,6 @@
       "@seam/domain/*": ["../domain/src/*"]
     }
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    ".expo/types/**/*.ts",
-    "expo-env.d.ts"
-  ],
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
   "exclude": ["node_modules", "dist", ".expo"]
 }

--- a/packages/domain/src/compare/compareMeasurements.test.ts
+++ b/packages/domain/src/compare/compareMeasurements.test.ts
@@ -59,11 +59,7 @@ describe('compareMeasurements', () => {
   });
 
   it('returns 0% for reference value of 0', () => {
-    const diffs = compareMeasurements(
-      [m('c', 'inseam', 5)],
-      [m('r', 'inseam', 0)],
-      'pants',
-    );
+    const diffs = compareMeasurements([m('c', 'inseam', 5)], [m('r', 'inseam', 0)], 'pants');
     expect(diffs).toHaveLength(1);
     expect(diffs[0]?.diffPct).toBe(0);
   });

--- a/packages/domain/src/compare/getMeasurementDiffSeverity.test.ts
+++ b/packages/domain/src/compare/getMeasurementDiffSeverity.test.ts
@@ -40,12 +40,24 @@ describe('getMeasurementDiffSeverity', () => {
 
   it('directional rule fires when bodyLength is short by absAtWarning cm', () => {
     // bodyLength sign=negative, absAtWarning=4 → -4cm or worse → warning.
-    const d = diff({ key: 'bodyLength', diffCm: -4, diffPct: -0.05, candidateValue: 76, referenceValue: 80 });
+    const d = diff({
+      key: 'bodyLength',
+      diffCm: -4,
+      diffPct: -0.05,
+      candidateValue: 76,
+      referenceValue: 80,
+    });
     expect(getMeasurementDiffSeverity(d, 't_shirt')).toBe('warning');
   });
 
   it('directional rule does NOT fire for positive bodyLength diff (item is longer)', () => {
-    const d = diff({ key: 'bodyLength', diffCm: 5, diffPct: 5 / 80, candidateValue: 85, referenceValue: 80 });
+    const d = diff({
+      key: 'bodyLength',
+      diffCm: 5,
+      diffPct: 5 / 80,
+      candidateValue: 85,
+      referenceValue: 80,
+    });
     // 5cm on 80 = 6.25% — within different (8%), abs 5/5 = 1 hits different exactly.
     expect(getMeasurementDiffSeverity(d, 't_shirt')).toBe('different');
   });
@@ -59,7 +71,13 @@ describe('getMeasurementDiffSeverity', () => {
     // pants close = 2cm OR 3% — 2.5cm on 80cm waist is 3.1% (close on abs not
     // hit: 2.5/2 = 1.25 > 1; pct: 3.1/3 = 1.04 > 1). Both above close, both
     // within different (4cm or 6%). Expect "different".
-    const d = diff({ key: 'waist', diffCm: 2.5, diffPct: 2.5 / 80, candidateValue: 82.5, referenceValue: 80 });
+    const d = diff({
+      key: 'waist',
+      diffCm: 2.5,
+      diffPct: 2.5 / 80,
+      candidateValue: 82.5,
+      referenceValue: 80,
+    });
     expect(getMeasurementDiffSeverity(d, 'pants')).toBe('different');
   });
 });

--- a/packages/domain/src/compare/getMeasurementDiffSeverity.ts
+++ b/packages/domain/src/compare/getMeasurementDiffSeverity.ts
@@ -51,8 +51,7 @@ export const getMeasurementDiffSeverity = (
     }
   }
 
-  const thresholds: SeverityThresholds =
-    DEFAULT_THRESHOLDS_BY_GROUP[measurementGroupOf(category)];
+  const thresholds: SeverityThresholds = DEFAULT_THRESHOLDS_BY_GROUP[measurementGroupOf(category)];
 
   const absDiff = Math.abs(diff.diffCm);
   const absPct = Math.abs(diff.diffPct);
@@ -60,8 +59,7 @@ export const getMeasurementDiffSeverity = (
   // "Looser of the two" → take the *minimum* normalised score across the
   // absolute-cm and the percentage axis. A normalised score <= 1 means the
   // diff is within that level's threshold.
-  const within = (abs: number, pct: number): boolean =>
-    Math.min(absDiff / abs, absPct / pct) <= 1;
+  const within = (abs: number, pct: number): boolean => Math.min(absDiff / abs, absPct / pct) <= 1;
 
   if (within(thresholds.sameAbs, thresholds.samePct)) return 'same';
   if (within(thresholds.closeAbs, thresholds.closePct)) return 'close';

--- a/packages/domain/src/compare/suggestSimilarItems.test.ts
+++ b/packages/domain/src/compare/suggestSimilarItems.test.ts
@@ -29,10 +29,7 @@ describe('suggestSimilarItems', () => {
   });
 
   it('filters by same category by default', () => {
-    const owned = [
-      item({ id: 'a', category: 't_shirt' }),
-      item({ id: 'b', category: 'pants' }),
-    ];
+    const owned = [item({ id: 'a', category: 't_shirt' }), item({ id: 'b', category: 'pants' })];
     expect(suggestSimilarItems(candidate, owned).map((i) => i.id)).toEqual(['a']);
   });
 
@@ -41,9 +38,9 @@ describe('suggestSimilarItems', () => {
       item({ id: 'a', category: 't_shirt', brand: 'Nike' }),
       item({ id: 'b', category: 't_shirt', brand: 'Adidas' }),
     ];
-    expect(
-      suggestSimilarItems(candidate, owned, { sameBrand: true }).map((i) => i.id),
-    ).toEqual(['a']);
+    expect(suggestSimilarItems(candidate, owned, { sameBrand: true }).map((i) => i.id)).toEqual([
+      'a',
+    ]);
   });
 
   it('ranks items with more matching attributes higher', () => {
@@ -52,11 +49,7 @@ describe('suggestSimilarItems', () => {
       item({ id: 'high', category: 't_shirt', brand: 'Nike', color: 'black', sizeLabel: 'L' }),
       item({ id: 'mid', category: 't_shirt', brand: 'Nike', color: 'white' }),
     ];
-    expect(suggestSimilarItems(candidate, owned).map((i) => i.id)).toEqual([
-      'high',
-      'mid',
-      'low',
-    ]);
+    expect(suggestSimilarItems(candidate, owned).map((i) => i.id)).toEqual(['high', 'mid', 'low']);
   });
 
   it('respects limit option', () => {

--- a/packages/domain/src/compare/suggestSimilarItems.ts
+++ b/packages/domain/src/compare/suggestSimilarItems.ts
@@ -38,7 +38,10 @@ export const suggestSimilarItems = (
   const filtered = ownedItems.filter((it) => {
     if (it.id === candidate.id) return false;
     if (opts.sameCategory && it.category !== candidate.category) return false;
-    if (opts.sameBrand && (it.brand ?? '').toLowerCase() !== (candidate.brand ?? '').toLowerCase()) {
+    if (
+      opts.sameBrand &&
+      (it.brand ?? '').toLowerCase() !== (candidate.brand ?? '').toLowerCase()
+    ) {
       return false;
     }
     return true;

--- a/packages/domain/src/pricing/calculatePriceScore.ts
+++ b/packages/domain/src/pricing/calculatePriceScore.ts
@@ -5,8 +5,7 @@ export type PriceScoreInput = {
   maxBidPrice?: number;
 };
 
-const isFiniteNumber = (n: unknown): n is number =>
-  typeof n === 'number' && Number.isFinite(n);
+const isFiniteNumber = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n);
 
 /**
  * Returns a 0-100 score that grades how favorable totalPrice is against the
@@ -25,9 +24,7 @@ const isFiniteNumber = (n: unknown): n is number =>
 export const calculatePriceScore = (input: PriceScoreInput): number => {
   const total = isFiniteNumber(input.totalPrice) ? input.totalPrice : undefined;
   const easy = isFiniteNumber(input.easyBuyPrice) ? input.easyBuyPrice : undefined;
-  const acceptable = isFiniteNumber(input.acceptablePrice)
-    ? input.acceptablePrice
-    : undefined;
+  const acceptable = isFiniteNumber(input.acceptablePrice) ? input.acceptablePrice : undefined;
   const max = isFiniteNumber(input.maxBidPrice) ? input.maxBidPrice : undefined;
 
   // Without a totalPrice we cannot compare anything → neutral.

--- a/packages/domain/src/pricing/calculateTotalPrice.ts
+++ b/packages/domain/src/pricing/calculateTotalPrice.ts
@@ -4,7 +4,6 @@
  */
 export const calculateTotalPrice = (price?: number, shippingFee?: number): number => {
   const p = typeof price === 'number' && Number.isFinite(price) ? price : 0;
-  const s =
-    typeof shippingFee === 'number' && Number.isFinite(shippingFee) ? shippingFee : 0;
+  const s = typeof shippingFee === 'number' && Number.isFinite(shippingFee) ? shippingFee : 0;
   return p + s;
 };

--- a/packages/domain/src/rules/evaluatePersonalMeasurementRules.test.ts
+++ b/packages/domain/src/rules/evaluatePersonalMeasurementRules.test.ts
@@ -93,17 +93,20 @@ describe('evaluatePersonalMeasurementRules', () => {
       operator: 'gt',
       value: 28,
     });
-    const violations = evaluatePersonalMeasurementRules(
-      [m('i', 'jpSize', 9, 'us')],
-      [r],
-      'shoes',
-    );
+    const violations = evaluatePersonalMeasurementRules([m('i', 'jpSize', 9, 'us')], [r], 'shoes');
     expect(violations).toEqual([]);
   });
 
   it('returns multiple violations independently', () => {
     const r1 = rule({ id: 'r1', operator: 'lt', value: 50 });
-    const r2 = rule({ id: 'r2', measurementKey: 'chestWidth', operator: 'gt', value: 60, severity: 'warning', message: 'too wide' });
+    const r2 = rule({
+      id: 'r2',
+      measurementKey: 'chestWidth',
+      operator: 'gt',
+      value: 60,
+      severity: 'warning',
+      message: 'too wide',
+    });
     const violations = evaluatePersonalMeasurementRules(
       [m('i', 'shoulderWidth', 45), m('i', 'chestWidth', 65)],
       [r1, r2],

--- a/packages/domain/src/scoring/calculateDuplicateRisk.test.ts
+++ b/packages/domain/src/scoring/calculateDuplicateRisk.test.ts
@@ -62,9 +62,7 @@ describe('calculateDuplicateRisk', () => {
   });
 
   it('compares case- and whitespace-insensitively', () => {
-    const owned = [
-      item({ id: '1', category: 'pants', brand: '  LEVI’S ', color: 'INDIGO ' }),
-    ];
+    const owned = [item({ id: '1', category: 'pants', brand: '  LEVI’S ', color: 'INDIGO ' })];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(40);
   });
 

--- a/packages/domain/src/scoring/calculateUniquenessScore.test.ts
+++ b/packages/domain/src/scoring/calculateUniquenessScore.test.ts
@@ -52,12 +52,18 @@ describe('calculateUniquenessScore', () => {
   });
 
   it('returns 40 for 5-6 same-category items', () => {
-    expect(calculateUniquenessScore(candidate, make(5, { category: 'pants', brand: 'Lee' }))).toBe(40);
-    expect(calculateUniquenessScore(candidate, make(6, { category: 'pants', brand: 'Lee' }))).toBe(40);
+    expect(calculateUniquenessScore(candidate, make(5, { category: 'pants', brand: 'Lee' }))).toBe(
+      40,
+    );
+    expect(calculateUniquenessScore(candidate, make(6, { category: 'pants', brand: 'Lee' }))).toBe(
+      40,
+    );
   });
 
   it('returns 20 for 7+ same-category items', () => {
-    expect(calculateUniquenessScore(candidate, make(7, { category: 'pants', brand: 'Lee' }))).toBe(20);
+    expect(calculateUniquenessScore(candidate, make(7, { category: 'pants', brand: 'Lee' }))).toBe(
+      20,
+    );
   });
 
   it('subtracts 5 per same-brand item', () => {

--- a/packages/domain/src/wear/calculateCostPerWear.ts
+++ b/packages/domain/src/wear/calculateCostPerWear.ts
@@ -11,10 +11,7 @@
  *     and a clamped `wearCount` of 0 still yields null.
  *   - Non-finite numbers (NaN, ±Infinity) are treated as missing → null.
  */
-export const calculateCostPerWear = (
-  totalPrice?: number,
-  wearCount?: number,
-): number | null => {
+export const calculateCostPerWear = (totalPrice?: number, wearCount?: number): number | null => {
   if (typeof totalPrice !== 'number' || !Number.isFinite(totalPrice)) return null;
   if (typeof wearCount !== 'number' || !Number.isFinite(wearCount)) return null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.13
+        version: 2.4.13
       turbo:
         specifier: 2.9.6
         version: 2.9.6
@@ -20,9 +23,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.29.2
         version: 7.29.2
-      '@expo/metro-runtime':
-        specifier: ~6.1.2
-        version: 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.74.0(react@19.1.0))
@@ -38,9 +38,6 @@ importers:
       '@seam/shared':
         specifier: workspace:*
         version: link:../shared
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
       drizzle-orm:
         specifier: ^0.45.0
         version: 0.45.2(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
@@ -89,9 +86,6 @@ importers:
       react:
         specifier: 19.1.0
         version: 19.1.0
-      react-dom:
-        specifier: 19.1.0
-        version: 19.1.0(react@19.1.0)
       react-hook-form:
         specifier: ^7.54.0
         version: 7.74.0(react@19.1.0)
@@ -113,9 +107,6 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
-      zustand:
-        specifier: ^5.0.2
-        version: 5.0.12(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
@@ -129,6 +120,12 @@ importers:
       drizzle-kit:
         specifier: 0.31.10
         version: 0.31.10
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4
+      eslint-config-expo:
+        specifier: ^55.0.0
+        version: 55.0.0(eslint@9.39.4)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -685,12 +682,78 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1282,6 +1345,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@expo/cli@54.0.23':
     resolution: {integrity: sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==}
     hasBin: true
@@ -1411,6 +1512,26 @@ packages:
     peerDependencies:
       react-hook-form: ^7.0.0
 
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
   '@ide/backoff@1.0.0':
     resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
@@ -1477,9 +1598,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nolyfill/is-core-module@1.0.39':
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -1995,6 +2123,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -2034,6 +2165,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2064,6 +2198,12 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -2079,8 +2219,170 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@typescript-eslint/eslint-plugin@8.59.0':
+    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.0':
+    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
 
   '@urql/core@5.2.0':
     resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
@@ -2148,6 +2450,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2156,6 +2463,9 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -2212,6 +2522,38 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -2221,6 +2563,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
@@ -2387,6 +2733,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -2515,8 +2865,17 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  date-fns@4.1.0:
-    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2555,6 +2914,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2588,6 +2950,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -2727,6 +3093,10 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2735,11 +3105,27 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-iterator-helpers@1.3.2:
+    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
@@ -2781,13 +3167,129 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-expo@55.0.0:
+    resolution: {integrity: sha512-YvhaKrp1g7pR/qjdI12E5nw9y0DJZWgYr815vyW8wskGLsFvxATY3mtKL8zm3ZYzWj3Bvc37tRIS661TEkrv9A==}
+    peerDependencies:
+      eslint: '>=8.10'
+
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
+
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
+  eslint-module-utils@2.12.1:
+    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-expo@1.0.0:
+    resolution: {integrity: sha512-qLtunR+cNFtC+jwYCBia5c/PJurMjSLMOV78KrEOyQK02ohZapU4dCFFnS2hfrJuw0zxfsjVkjqg3QBqi933QA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      eslint: '>=8.10'
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
 
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -2968,6 +3470,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
@@ -2979,6 +3484,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2995,6 +3504,17 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
@@ -3029,6 +3549,13 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3057,12 +3584,20 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -3077,12 +3612,28 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -3094,6 +3645,10 @@ packages:
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3156,10 +3711,18 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   image-size@1.2.1:
     resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3175,6 +3738,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -3182,8 +3749,27 @@ packages:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -3193,10 +3779,26 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -3206,8 +3808,24 @@ packages:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
@@ -3222,13 +3840,44 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3252,6 +3901,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -3314,10 +3967,30 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3330,6 +4003,10 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -3415,8 +4092,15 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
@@ -3658,6 +4342,14 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -3672,6 +4364,10 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
+
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
 
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
@@ -3706,6 +4402,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-is@1.1.6:
     resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
@@ -3716,6 +4416,22 @@ packages:
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
   on-finished@2.3.0:
@@ -3745,9 +4461,17 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@3.4.0:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
     engines: {node: '>=6'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3761,12 +4485,20 @@ packages:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
 
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
 
   parse-png@2.1.0:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
@@ -3848,6 +4580,10 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -3870,6 +4606,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4014,6 +4753,10 @@ packages:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -4023,6 +4766,10 @@ packages:
 
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
@@ -4050,6 +4797,10 @@ packages:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -4072,6 +4823,11 @@ packages:
   resolve@1.7.1:
     resolution: {integrity: sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==}
 
+  resolve@2.0.0-next.6:
+    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
@@ -4086,8 +4842,16 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
 
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
@@ -4133,6 +4897,14 @@ packages:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -4153,6 +4925,22 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -4204,6 +4992,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -4229,6 +5020,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
@@ -4245,6 +5040,25 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
@@ -4257,9 +5071,17 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
@@ -4353,8 +5175,17 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4368,6 +5199,10 @@ packages:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -4380,10 +5215,30 @@ packages:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -4412,11 +5267,17 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4557,6 +5418,18 @@ packages:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
@@ -4573,6 +5446,10 @@ packages:
 
   wonka@6.3.6:
     resolution: {integrity: sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==}
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4673,24 +5550,6 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zustand@5.0.12:
-    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@types/react': '>=18.0.0'
-      immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-      use-sync-external-store:
-        optional: true
 
 snapshots:
 
@@ -5313,11 +6172,62 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    optional: true
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -5619,6 +6529,52 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
 
   '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
@@ -5934,6 +6890,22 @@ snapshots:
     dependencies:
       react-hook-form: 7.74.0(react@19.1.0)
 
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
   '@ide/backoff@1.0.0': {}
 
   '@isaacs/cliui@8.0.2':
@@ -6038,7 +7010,16 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/hashes@1.8.0': {}
+
+  '@nolyfill/is-core-module@1.0.39': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -6582,6 +7563,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@rtsao/scc@1.1.0': {}
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sinonjs/commons@3.0.1':
@@ -6608,6 +7591,11 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.9.6':
+    optional: true
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@types/babel__core@7.20.5':
@@ -6649,6 +7637,10 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -6665,7 +7657,157 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.0': {}
+
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      eslint-visitor-keys: 5.0.1
+
   '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
 
   '@urql/core@5.2.0':
     dependencies:
@@ -6755,9 +7897,20 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   anser@1.4.10: {}
 
@@ -6802,6 +7955,73 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   asap@2.0.6: {}
 
   assert@2.1.0:
@@ -6813,6 +8033,8 @@ snapshots:
       util: 0.12.5
 
   assertion-error@2.0.1: {}
+
+  async-function@1.0.0: {}
 
   async-limiter@1.0.1: {}
 
@@ -7042,6 +8264,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -7182,7 +8406,23 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  date-fns@4.1.0: {}
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
 
   debug@2.6.9:
     dependencies:
@@ -7201,6 +8441,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
+
+  deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
 
@@ -7229,6 +8471,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -7273,15 +8519,108 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
 
   es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.3
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -7402,11 +8741,194 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-expo@55.0.0(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-plugin-expo: 1.0.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4)
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
+      globals: 16.5.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+      - typescript
+
+  eslint-import-resolver-node@0.3.10:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 2.0.0-next.6
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-expo@1.0.0(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      hasown: 2.0.3
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4):
+    dependencies:
+      eslint: 9.39.4
+
+  eslint-plugin-react@7.37.5(eslint@9.39.4):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4
+      estraverse: 5.3.0
+      hasown: 2.0.3
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -7620,6 +9142,8 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-levenshtein@2.0.6: {}
+
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
@@ -7627,6 +9151,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   fill-range@7.1.1:
     dependencies:
@@ -7651,6 +9179,18 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
   flow-enums-runtime@0.0.6: {}
 
   fontfaceobserver@2.3.0: {}
@@ -7674,6 +9214,17 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.3
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
 
@@ -7703,11 +9254,21 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   getenv@2.0.0: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -7733,9 +9294,20 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  globals@14.0.0: {}
+
+  globals@16.5.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  has-bigints@1.1.0: {}
 
   has-flag@3.0.0: {}
 
@@ -7744,6 +9316,10 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -7808,9 +9384,16 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   image-size@1.2.1:
     dependencies:
       queue: 6.0.2
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -7823,6 +9406,12 @@ snapshots:
 
   ini@1.3.8: {}
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.3
+      side-channel: 1.1.0
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -7832,7 +9421,34 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-arrayish@0.3.4: {}
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.7.4
 
   is-callable@1.2.7: {}
 
@@ -7840,7 +9456,24 @@ snapshots:
     dependencies:
       hasown: 2.0.3
 
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-docker@2.2.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -7852,10 +9485,23 @@ snapshots:
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
 
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-map@2.0.3: {}
+
   is-nan@1.3.2:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
 
@@ -7868,13 +9514,43 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.3
 
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -7908,6 +9584,15 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  iterator.prototype@1.1.5:
+    dependencies:
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
 
   jackspeak@3.4.3:
     dependencies:
@@ -8004,13 +9689,39 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
   json5@2.2.3: {}
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   kleur@3.0.3: {}
 
   lan-network@0.1.7: {}
 
   leven@3.1.0: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -8074,7 +9785,13 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash.debounce@4.0.8: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash.throttle@4.1.1: {}
 
@@ -8531,6 +10248,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-postinstall@0.3.4: {}
+
+  natural-compare@1.4.0: {}
+
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
@@ -8538,6 +10259,13 @@ snapshots:
   negotiator@1.0.0: {}
 
   nested-error-stacks@2.0.1: {}
+
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
 
   node-forge@1.4.0: {}
 
@@ -8566,6 +10294,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   object-is@1.1.6:
     dependencies:
       call-bind: 1.0.9
@@ -8581,6 +10311,33 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   on-finished@2.3.0:
     dependencies:
@@ -8611,6 +10368,15 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@3.4.0:
     dependencies:
       chalk: 2.4.2
@@ -8619,6 +10385,12 @@ snapshots:
       log-symbols: 2.2.0
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   p-limit@2.3.0:
     dependencies:
@@ -8632,9 +10404,17 @@ snapshots:
     dependencies:
       p-limit: 2.3.0
 
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
 
   parse-png@2.1.0:
     dependencies:
@@ -8698,6 +10478,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   pretty-bytes@5.6.0: {}
 
   pretty-format@29.7.0:
@@ -8718,6 +10500,12 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   punycode@2.3.1: {}
 
@@ -8904,6 +10692,17 @@ snapshots:
 
   react@19.1.0: {}
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -8911,6 +10710,15 @@ snapshots:
   regenerate@1.4.2: {}
 
   regenerator-runtime@0.13.11: {}
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   regexpu-core@6.4.0:
     dependencies:
@@ -8941,6 +10749,8 @@ snapshots:
       rc: 1.2.8
       resolve: 1.7.1
 
+  resolve-from@4.0.0: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -8959,6 +10769,15 @@ snapshots:
   resolve@1.7.1:
     dependencies:
       path-parse: 1.0.7
+
+  resolve@2.0.0-next.6:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@2.0.0:
     dependencies:
@@ -9000,7 +10819,20 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
   safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -9058,6 +10890,19 @@ snapshots:
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
   setprototypeof@1.2.0: {}
 
   sf-symbols-typescript@2.2.0: {}
@@ -9071,6 +10916,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -9109,6 +10982,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stable-hash@0.0.5: {}
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -9127,6 +11002,11 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   stream-buffers@2.2.0: {}
 
   strict-uri-encode@2.0.0: {}
@@ -9143,6 +11023,50 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.0
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
@@ -9155,7 +11079,11 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-bom@3.0.0: {}
+
   strip-json-comments@2.0.1: {}
+
+  strip-json-comments@3.1.1: {}
 
   structured-headers@0.4.1: {}
 
@@ -9253,7 +11181,18 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@2.8.1: {}
 
@@ -9273,13 +11212,57 @@ snapshots:
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript@5.9.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@7.19.2: {}
 
@@ -9298,11 +11281,39 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
@@ -9438,6 +11449,37 @@ snapshots:
       punycode: 2.3.1
       webidl-conversions: 5.0.0
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -9458,6 +11500,8 @@ snapshots:
       stackback: 0.0.2
 
   wonka@6.3.6: {}
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -9527,9 +11571,3 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
-
-  zustand@5.0.12(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)):
-    optionalDependencies:
-      '@types/react': 19.1.17
-      react: 19.1.0
-      use-sync-external-store: 1.6.0(react@19.1.0)


### PR DESCRIPTION
## Summary
- 未使用依存を整理: `date-fns`, `zustand`, `react-dom`, `@expo/metro-runtime` を削除。Web/Android はビルド予定がないため `web` / `android` script も削除
- Formatter として Biome を **format-only** で導入（`biome.json`、`pnpm format` / `pnpm format:check`）。Linter は ESLint を担当するので Biome 側の linter は無効化
- Linter として ESLint + `eslint-config-expo`（flat config）を `@seam/app` に導入。`--max-warnings 0` で警告も CI で落とす
- 既存コードに Biome を一括適用 + ESLint の自動修正で警告ゼロまで整理（`Array<T>` → `T[]`、重複 import の統合、不要な `eslint-disable` ディレクティブの削除）
- CI ワークフロー (`.github/workflows/test.yml`) に `Format check` と `Lint` ステップを追加

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm format:check`
- [x] `pnpm -r lint`（0 warnings, 0 errors）
- [x] `pnpm typecheck`
- [x] `pnpm test`（domain 144 / app 28 / shared 11 全 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)