### PR TITLE
feat(closet): Sold アイテムを閲覧・検索・フィルタできる二モード化 + Renovate/CI 強化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Expo SDK peer alignment
+        # Catches drift between installed react / react-native / expo-* and
+        # what the active Expo SDK expects. A patch bump that slips past the
+        # Renovate `react + react-native` group would fail here at PR time.
+        run: pnpm --filter @seam/app exec expo install --check
+
       - name: Format check
         run: pnpm format:check
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,30 @@
+# Git hooks managed by lefthook (https://github.com/evilmartians/lefthook).
+# Installed by the `prepare` script in package.json on `pnpm install`.
+#
+# Strategy:
+#   - pre-commit:  fast, autofixable on staged files only (Biome format).
+#                  Keeps commit latency near-instant; lint and type errors
+#                  surface at push time instead of blocking iteration.
+#   - pre-push:    full CI-equivalent gate (format check + lint + typecheck +
+#                  test). Acts as a safety net so `--no-verify` on commit
+#                  doesn't leak into shared history.
+
+pre-commit:
+  parallel: true
+  commands:
+    biome-format:
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs,json}"
+      run: pnpm exec biome format --write --no-errors-on-unmatched {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: true
+  commands:
+    format-check:
+      run: pnpm format:check
+    lint:
+      run: pnpm -r lint
+    typecheck:
+      run: pnpm -r typecheck
+    test:
+      run: pnpm -r test

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "dev": "turbo run dev --parallel",
-    "clean": "turbo run clean && rm -rf node_modules .turbo"
+    "clean": "turbo run clean && rm -rf node_modules .turbo",
+    "prepare": "lefthook install"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
+    "lefthook": "^2.1.6",
     "turbo": "2.9.6",
     "typescript": "5.9.3"
   },
@@ -25,7 +27,8 @@
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "lefthook"
     ]
   }
 }

--- a/packages/app/app/(tabs)/closet.tsx
+++ b/packages/app/app/(tabs)/closet.tsx
@@ -8,23 +8,27 @@ import {
   type ListRenderItemInfo,
   type ViewStyle,
 } from 'react-native';
-import { useFocusEffect, router } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, router } from 'expo-router';
 import {
   CATEGORY_LABEL,
   GARMENT_CATEGORIES,
   type GarmentCategory,
   type GarmentItem,
   type ItemPhoto,
+  type SaleInfo,
 } from '@seam/shared';
 import { Chip } from '../../src/components/Chip';
 import { EmptyState } from '../../src/components/EmptyState';
 import { ItemCard } from '../../src/components/ItemCard';
 import { Picker, type PickerOption } from '../../src/components/Picker';
+import { SegmentedControl } from '../../src/components/SegmentedControl';
 import { itemRepository, photoRepository, wearLogRepository } from '../../src/repositories';
-import type { ItemSort } from '../../src/repositories';
+import type { ItemSort, SoldItem } from '../../src/repositories';
 import { colors, font, radii, space } from '../../src/theme';
 
-const SORT_OPTIONS: readonly PickerOption<ItemSort>[] = [
+type ClosetMode = 'owned' | 'sold';
+
+const OWNED_SORT_OPTIONS: readonly PickerOption<ItemSort>[] = [
   { value: 'createdAt_desc', label: '新しい順' },
   { value: 'purchaseDate_desc', label: '購入日が新しい順' },
   { value: 'purchasePrice_desc', label: '価格が高い順' },
@@ -33,43 +37,150 @@ const SORT_OPTIONS: readonly PickerOption<ItemSort>[] = [
   { value: 'brand_asc', label: 'ブランド順' },
 ];
 
+const SOLD_SORT_OPTIONS: readonly PickerOption<ItemSort>[] = [
+  { value: 'soldAt_desc', label: '売却日が新しい順' },
+  { value: 'soldAt_asc', label: '売却日が古い順' },
+  { value: 'recoveryRate_desc', label: '回収率が高い順' },
+  { value: 'netCpw_asc', label: 'Net CPW が良い順' },
+  { value: 'purchaseDate_desc', label: '購入日が新しい順' },
+  { value: 'category_asc', label: 'カテゴリ順' },
+];
+
+type RecoveryRangeKey = 'all' | 'high' | 'mid' | 'low' | 'veryLow';
+
+const RECOVERY_RANGE_OPTIONS: readonly PickerOption<RecoveryRangeKey>[] = [
+  { value: 'all', label: 'すべて' },
+  { value: 'high', label: '80% 以上' },
+  { value: 'mid', label: '50–80%' },
+  { value: 'low', label: '30–50%' },
+  { value: 'veryLow', label: '30% 未満' },
+];
+
+const RECOVERY_RANGE_LABEL: Record<RecoveryRangeKey, string> = {
+  all: '回収率',
+  high: '回収 80%+',
+  mid: '回収 50–80%',
+  low: '回収 30–50%',
+  veryLow: '回収 <30%',
+};
+
+const recoveryRangeBounds = (
+  key: RecoveryRangeKey,
+): { min?: number; max?: number } => {
+  switch (key) {
+    case 'all':
+      return {};
+    case 'high':
+      return { min: 0.8 };
+    case 'mid':
+      return { min: 0.5, max: 0.8 };
+    case 'low':
+      return { min: 0.3, max: 0.5 };
+    case 'veryLow':
+      return { max: 0.3 };
+  }
+};
+
+const yearBounds = (year: number): { from: string; to: string } => ({
+  from: `${year}-01-01`,
+  to: `${year + 1}-01-01`,
+});
+
 export default function ClosetScreen() {
-  const [items, setItems] = useState<GarmentItem[]>([]);
-  const [thumbnails, setThumbnails] = useState<Record<string, string | undefined>>({});
-  const [wearCounts, setWearCounts] = useState<Record<string, number>>({});
-  const [sort, setSort] = useState<ItemSort>('createdAt_desc');
+  const params = useLocalSearchParams<{ mode?: string }>();
+  const initialMode: ClosetMode = params.mode === 'sold' ? 'sold' : 'owned';
+
+  const [mode, setMode] = useState<ClosetMode>(initialMode);
+  const [ownedSort, setOwnedSort] = useState<ItemSort>('createdAt_desc');
+  const [soldSort, setSoldSort] = useState<ItemSort>('soldAt_desc');
   const [search, setSearch] = useState('');
   const [categoryFilters, setCategoryFilters] = useState<Set<GarmentCategory>>(new Set());
   const [anchorOnly, setAnchorOnly] = useState(false);
+  const [soldYear, setSoldYear] = useState<number | undefined>(undefined);
+  const [recoveryRange, setRecoveryRange] = useState<RecoveryRangeKey>('all');
+
+  const [ownedItems, setOwnedItems] = useState<GarmentItem[]>([]);
+  const [soldItems, setSoldItems] = useState<SoldItem[]>([]);
+  const [thumbnails, setThumbnails] = useState<Record<string, string | undefined>>({});
+  const [wearCounts, setWearCounts] = useState<Record<string, number>>({});
+  const [counts, setCounts] = useState<{ owned: number; sold: number }>({ owned: 0, sold: 0 });
+  const [yearOptions, setYearOptions] = useState<readonly PickerOption<string>[]>([
+    { value: '', label: 'すべて' },
+  ]);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (initialMode !== mode) setMode(initialMode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialMode]);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const list = await itemRepository.list(
-        {
-          statuses: ['owned'],
-          categories: categoryFilters.size > 0 ? [...categoryFilters] : undefined,
-          isFitAnchor: anchorOnly ? true : undefined,
-          search: search.trim() === '' ? undefined : search.trim(),
-        },
-        sort,
-      );
-      setItems(list);
-      const map: Record<string, string | undefined> = {};
-      await Promise.all(
-        list.map(async (it) => {
-          const photos: ItemPhoto[] = await photoRepository.listByItem(it.id);
-          map[it.id] = photos[0]?.thumbnailRelativePath ?? photos[0]?.relativePath;
-        }),
-      );
-      setThumbnails(map);
-      const counts = await wearLogRepository.countsByItems(list.map((it) => it.id));
-      setWearCounts(counts);
+      const trimmedSearch = search.trim() === '' ? undefined : search.trim();
+      const categories = categoryFilters.size > 0 ? [...categoryFilters] : undefined;
+
+      if (mode === 'owned') {
+        const list = await itemRepository.list(
+          {
+            statuses: ['owned'],
+            categories,
+            isFitAnchor: anchorOnly ? true : undefined,
+            search: trimmedSearch,
+          },
+          ownedSort,
+        );
+        setOwnedItems(list);
+        const map: Record<string, string | undefined> = {};
+        await Promise.all(
+          list.map(async (it) => {
+            const photos: ItemPhoto[] = await photoRepository.listByItem(it.id);
+            map[it.id] = photos[0]?.thumbnailRelativePath ?? photos[0]?.relativePath;
+          }),
+        );
+        setThumbnails(map);
+        const c = await wearLogRepository.countsByItems(list.map((it) => it.id));
+        setWearCounts(c);
+      } else {
+        const range = recoveryRangeBounds(recoveryRange);
+        const yearWindow = soldYear !== undefined ? yearBounds(soldYear) : undefined;
+        const list = await itemRepository.listSold(
+          {
+            categories,
+            search: trimmedSearch,
+            soldAtFrom: yearWindow?.from,
+            soldAtTo: yearWindow?.to,
+            recoveryRateMin: range.min,
+            recoveryRateMax: range.max,
+          },
+          soldSort,
+        );
+        setSoldItems(list);
+        const map: Record<string, string | undefined> = {};
+        await Promise.all(
+          list.map(async (it) => {
+            const photos: ItemPhoto[] = await photoRepository.listByItem(it.id);
+            map[it.id] = photos[0]?.thumbnailRelativePath ?? photos[0]?.relativePath;
+          }),
+        );
+        setThumbnails(map);
+      }
+
+      const totals = await itemRepository.countByStatus();
+      setCounts({ owned: totals.owned ?? 0, sold: totals.sold ?? 0 });
     } finally {
       setLoading(false);
     }
-  }, [sort, search, categoryFilters, anchorOnly]);
+  }, [
+    mode,
+    ownedSort,
+    soldSort,
+    search,
+    categoryFilters,
+    anchorOnly,
+    soldYear,
+    recoveryRange,
+  ]);
 
   useFocusEffect(
     useCallback(() => {
@@ -81,6 +192,42 @@ export default function ClosetScreen() {
     void load();
   }, [load]);
 
+  // Build the sold-year picker options from existing sale dates whenever we
+  // visit Sold mode. This stays scoped to actual data the user has, so empty
+  // years don't pollute the picker.
+  useEffect(() => {
+    if (mode !== 'sold') return;
+    let cancelled = false;
+    void (async () => {
+      const all = await itemRepository.listSold({}, 'soldAt_desc');
+      if (cancelled) return;
+      const years = new Set<number>();
+      for (const it of all) {
+        const at = it.saleInfo.soldAt;
+        if (!at) continue;
+        const y = Number(at.slice(0, 4));
+        if (Number.isFinite(y)) years.add(y);
+      }
+      const sorted = [...years].sort((a, b) => b - a);
+      setYearOptions([
+        { value: '', label: 'すべて' },
+        ...sorted.map((y) => ({ value: String(y), label: `${y} 年` })),
+      ]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode]);
+
+  const switchMode = (next: ClosetMode) => {
+    if (next === mode) return;
+    if (next === 'sold' && anchorOnly) {
+      // Anchor is an owned-only concept; clear it on the way to Sold.
+      setAnchorOnly(false);
+    }
+    setMode(next);
+  };
+
   const toggleCategory = (c: GarmentCategory): void => {
     setCategoryFilters((prev) => {
       const next = new Set(prev);
@@ -90,7 +237,7 @@ export default function ClosetScreen() {
     });
   };
 
-  const renderItem = ({ item }: ListRenderItemInfo<GarmentItem>) => (
+  const renderOwned = ({ item }: ListRenderItemInfo<GarmentItem>) => (
     <ItemCard
       item={item}
       thumbnailRelativePath={thumbnails[item.id]}
@@ -99,10 +246,43 @@ export default function ClosetScreen() {
     />
   );
 
+  const renderSold = ({ item }: ListRenderItemInfo<SoldItem>) => {
+    const sale: SaleInfo = item.saleInfo;
+    return (
+      <ItemCard
+        item={item}
+        thumbnailRelativePath={thumbnails[item.id]}
+        saleInfo={sale}
+        recoveryRate={item.recoveryRate}
+        onPress={() => router.push({ pathname: '/item/[id]', params: { id: item.id } })}
+      />
+    );
+  };
+
   const filterChips = useMemo(() => GARMENT_CATEGORIES, []);
+  const sortOptions = mode === 'owned' ? OWNED_SORT_OPTIONS : SOLD_SORT_OPTIONS;
+  const sortValue = mode === 'owned' ? ownedSort : soldSort;
+  const onSortChange = mode === 'owned' ? setOwnedSort : setSoldSort;
+
+  const items: GarmentItem[] | SoldItem[] = mode === 'owned' ? ownedItems : soldItems;
+  const isEmpty = items.length === 0;
+  const recoveryLabel =
+    recoveryRange === 'all' ? RECOVERY_RANGE_LABEL.all : RECOVERY_RANGE_LABEL[recoveryRange];
+  const yearLabel = soldYear !== undefined ? `${soldYear} 年` : '売却年';
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      <View style={segmentWrap}>
+        <SegmentedControl<ClosetMode>
+          value={mode}
+          options={[
+            { value: 'owned', label: '所有中', badge: counts.owned },
+            { value: 'sold', label: '売却済み', badge: counts.sold },
+          ]}
+          onChange={switchMode}
+        />
+      </View>
+
       <View style={header}>
         <TextInput
           value={search}
@@ -114,13 +294,35 @@ export default function ClosetScreen() {
           returnKeyType="search"
         />
         <Picker<ItemSort>
-          value={sort}
-          options={SORT_OPTIONS}
-          onChange={setSort}
+          value={sortValue}
+          options={sortOptions}
+          onChange={onSortChange}
           containerStyle={{ marginBottom: 0, flex: 1 }}
           modalTitle="並び替え"
         />
       </View>
+
+      {mode === 'sold' && (
+        <View style={soldFilterRow}>
+          <Picker<string>
+            value={soldYear !== undefined ? String(soldYear) : ''}
+            options={yearOptions}
+            onChange={(v) => setSoldYear(v === '' ? undefined : Number(v))}
+            containerStyle={{ marginBottom: 0, flex: 1 }}
+            placeholder={yearLabel}
+            modalTitle="売却年"
+          />
+          <Picker<RecoveryRangeKey>
+            value={recoveryRange}
+            options={RECOVERY_RANGE_OPTIONS}
+            onChange={setRecoveryRange}
+            containerStyle={{ marginBottom: 0, flex: 1 }}
+            placeholder={recoveryLabel}
+            modalTitle="回収率"
+          />
+        </View>
+      )}
+
       <View style={chipScrollWrapper}>
         <FlatList
           horizontal
@@ -129,14 +331,16 @@ export default function ClosetScreen() {
           keyExtractor={(c) => c}
           contentContainerStyle={{ paddingHorizontal: space.lg, gap: space.xs }}
           ListHeaderComponent={
-            <View style={{ marginRight: space.xs }}>
-              <Chip
-                label="Anchor"
-                tone={anchorOnly ? 'inverse' : 'muted'}
-                onPress={() => setAnchorOnly((v) => !v)}
-                selected={anchorOnly}
-              />
-            </View>
+            mode === 'owned' ? (
+              <View style={{ marginRight: space.xs }}>
+                <Chip
+                  label="Anchor"
+                  tone={anchorOnly ? 'inverse' : 'muted'}
+                  onPress={() => setAnchorOnly((v) => !v)}
+                  selected={anchorOnly}
+                />
+              </View>
+            ) : null
           }
           renderItem={({ item }) => (
             <Chip
@@ -149,42 +353,72 @@ export default function ClosetScreen() {
         />
       </View>
 
-      {loading && items.length === 0 ? (
+      {loading && isEmpty ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <Text style={{ color: colors.textMuted }}>読み込み中…</Text>
         </View>
-      ) : items.length === 0 ? (
-        <EmptyState
-          title="まだ手持ち服がありません"
-          message="右下の + から登録してみましょう"
-          actionLabel="新規登録"
-          onAction={() => router.push('/item/new')}
+      ) : isEmpty ? (
+        mode === 'owned' ? (
+          <EmptyState
+            title="まだ手持ち服がありません"
+            message="右下の + から登録してみましょう"
+            actionLabel="新規登録"
+            onAction={() => router.push('/item/new')}
+          />
+        ) : (
+          <EmptyState
+            title="売却済みのアイテムはまだありません"
+            message="所有アイテムを売却すると、ここに記録されます"
+          />
+        )
+      ) : mode === 'owned' ? (
+        <FlatList
+          data={ownedItems}
+          keyExtractor={(it) => it.id}
+          renderItem={renderOwned}
+          contentContainerStyle={{ paddingBottom: 96 }}
         />
       ) : (
         <FlatList
-          data={items}
+          data={soldItems}
           keyExtractor={(it) => it.id}
-          renderItem={renderItem}
+          renderItem={renderSold}
           contentContainerStyle={{ paddingBottom: 96 }}
         />
       )}
 
-      <Pressable
-        accessibilityRole="button"
-        onPress={() => router.push('/item/new')}
-        style={({ pressed }) => [fab, pressed && { opacity: 0.85 }]}
-      >
-        <Text style={fabText}>＋</Text>
-      </Pressable>
+      {mode === 'owned' && (
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.push('/item/new')}
+          style={({ pressed }) => [fab, pressed && { opacity: 0.85 }]}
+        >
+          <Text style={fabText}>＋</Text>
+        </Pressable>
+      )}
     </View>
   );
 }
+
+const segmentWrap: ViewStyle = {
+  paddingHorizontal: space.lg,
+  paddingTop: space.md,
+};
 
 const header: ViewStyle = {
   flexDirection: 'row',
   alignItems: 'center',
   paddingHorizontal: space.lg,
   paddingTop: space.md,
+  paddingBottom: space.sm,
+  gap: space.sm,
+  backgroundColor: colors.bg,
+};
+
+const soldFilterRow: ViewStyle = {
+  flexDirection: 'row',
+  alignItems: 'center',
+  paddingHorizontal: space.lg,
   paddingBottom: space.sm,
   gap: space.sm,
   backgroundColor: colors.bg,

--- a/packages/app/app/(tabs)/closet.tsx
+++ b/packages/app/app/(tabs)/closet.tsx
@@ -64,9 +64,7 @@ const RECOVERY_RANGE_LABEL: Record<RecoveryRangeKey, string> = {
   veryLow: '回収 <30%',
 };
 
-const recoveryRangeBounds = (
-  key: RecoveryRangeKey,
-): { min?: number; max?: number } => {
+const recoveryRangeBounds = (key: RecoveryRangeKey): { min?: number; max?: number } => {
   switch (key) {
     case 'all':
       return {};
@@ -171,16 +169,7 @@ export default function ClosetScreen() {
     } finally {
       setLoading(false);
     }
-  }, [
-    mode,
-    ownedSort,
-    soldSort,
-    search,
-    categoryFilters,
-    anchorOnly,
-    soldYear,
-    recoveryRange,
-  ]);
+  }, [mode, ownedSort, soldSort, search, categoryFilters, anchorOnly, soldYear, recoveryRange]);
 
   useFocusEffect(
     useCallback(() => {

--- a/packages/app/app/(tabs)/stats.tsx
+++ b/packages/app/app/(tabs)/stats.tsx
@@ -106,7 +106,15 @@ export default function StatsScreen() {
             value={snapshot.sellCandidates.length}
             tone={snapshot.sellCandidates.length > 0 ? 'warning' : 'default'}
           />
-          <StatCard title="売却済み" value={totals.sold} />
+          <StatCard
+            title="売却済み"
+            value={totals.sold}
+            onPress={
+              totals.sold > 0
+                ? () => router.push({ pathname: '/(tabs)/closet', params: { mode: 'sold' } })
+                : undefined
+            }
+          />
         </View>
       </Section>
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,9 +37,9 @@
     "expo-sharing": "~14.0.8",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
-    "react": "19.1.6",
+    "react": "19.1.0",
     "react-hook-form": "^7.54.0",
-    "react-native": "0.81.6",
+    "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.7",
     "react-native-safe-area-context": "5.6.2",
@@ -52,7 +52,7 @@
     "babel-plugin-inline-import": "3.0.0",
     "drizzle-kit": "0.31.10",
     "eslint": "^9.39.4",
-    "eslint-config-expo": "^55.0.0",
+    "eslint-config-expo": "^10.0.0",
     "typescript": "5.9.3",
     "vitest": "2.1.9"
   }

--- a/packages/app/src/components/ItemCard.tsx
+++ b/packages/app/src/components/ItemCard.tsx
@@ -1,6 +1,6 @@
 import { Image, Pressable, Text, View, type ViewStyle } from 'react-native';
-import { CATEGORY_LABEL, ITEM_STATUS_LABEL, type GarmentItem } from '@seam/shared';
-import { Chip } from './Chip';
+import { CATEGORY_LABEL, ITEM_STATUS_LABEL, type GarmentItem, type SaleInfo } from '@seam/shared';
+import { Chip, type ChipTone } from './Chip';
 import { absolutePathFor } from '../photos/savePhoto';
 import { colors, font, radii, space } from '../theme';
 
@@ -9,14 +9,50 @@ type Props = {
   thumbnailRelativePath?: string;
   /** Optional wear count to display as a chip; pass when known to highlight unworn items. */
   wearCount?: number;
+  /** Sold-context info. When item.status === 'sold' and this is provided, sold metrics are shown. */
+  saleInfo?: SaleInfo;
+  /** soldPrice / totalPrice. Pass alongside `saleInfo` to render a recovery-rate chip. */
+  recoveryRate?: number;
   onPress?: () => void;
 };
 
-export const ItemCard = ({ item, thumbnailRelativePath, wearCount, onPress }: Props) => {
+const formatYen = (n?: number): string => (n !== undefined ? `¥${n.toLocaleString()}` : '—');
+
+const formatYearMonthDay = (iso?: string): string | undefined => {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso.length >= 10 ? iso.slice(0, 10) : iso;
+  }
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+const recoveryTone = (rate: number): ChipTone => {
+  if (rate >= 0.8) return 'default';
+  if (rate < 0.4) return 'warning';
+  return 'muted';
+};
+
+export const ItemCard = ({
+  item,
+  thumbnailRelativePath,
+  wearCount,
+  saleInfo,
+  recoveryRate,
+  onPress,
+}: Props) => {
+  const isSold = item.status === 'sold';
   const subtitleParts = [item.brand, item.sizeLabel, CATEGORY_LABEL[item.category]].filter(
     (p): p is string => Boolean(p),
   );
-  const isUnworn = item.status === 'owned' && wearCount !== undefined && wearCount === 0;
+  const isUnworn = !isSold && item.status === 'owned' && wearCount !== undefined && wearCount === 0;
+
+  const soldDate = isSold ? formatYearMonthDay(saleInfo?.soldAt) : undefined;
+  const soldMetaParts = [soldDate, saleInfo?.soldSource].filter((p): p is string => Boolean(p));
+
   const content = (
     <View style={card}>
       <View style={thumbBox}>
@@ -36,23 +72,37 @@ export const ItemCard = ({ item, thumbnailRelativePath, wearCount, onPress }: Pr
           <Text style={nameStyle} numberOfLines={1}>
             {item.name}
           </Text>
-          {item.isFitAnchor && <Chip label="Anchor" tone="inverse" />}
+          {!isSold && item.isFitAnchor && <Chip label="Anchor" tone="inverse" />}
         </View>
         {subtitleParts.length > 0 && (
           <Text style={subtitleStyle} numberOfLines={1}>
             {subtitleParts.join(' · ')}
           </Text>
         )}
+        {isSold && soldMetaParts.length > 0 && (
+          <Text style={subtitleStyle} numberOfLines={1}>
+            {soldMetaParts.join(' · ')}
+          </Text>
+        )}
         <View style={badgeRow}>
           <Chip label={ITEM_STATUS_LABEL[item.status]} tone="muted" />
-          {item.favoriteScore !== undefined && (
+          {!isSold && item.favoriteScore !== undefined && (
             <Chip label={`★ ${item.favoriteScore}`} tone="default" />
           )}
-          {item.isSellCandidate && <Chip label="売却候補" tone="warning" />}
-          {wearCount !== undefined && item.status === 'owned' && (
+          {!isSold && item.isSellCandidate && <Chip label="売却候補" tone="warning" />}
+          {!isSold && wearCount !== undefined && item.status === 'owned' && (
             <Chip
               label={isUnworn ? '未着用' : `着用 ${wearCount}回`}
               tone={isUnworn ? 'warning' : 'default'}
+            />
+          )}
+          {isSold && saleInfo?.soldPrice !== undefined && (
+            <Chip label={`売却 ${formatYen(saleInfo.soldPrice)}`} tone="default" />
+          )}
+          {isSold && recoveryRate !== undefined && (
+            <Chip
+              label={`回収 ${Math.round(recoveryRate * 100)}%`}
+              tone={recoveryTone(recoveryRate)}
             />
           )}
         </View>

--- a/packages/app/src/components/SegmentedControl.tsx
+++ b/packages/app/src/components/SegmentedControl.tsx
@@ -1,0 +1,108 @@
+import { Pressable, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { colors, font, radii, space } from '../theme';
+
+export type SegmentOption<T extends string> = {
+  value: T;
+  label: string;
+  /** Optional badge such as a count. Numbers are rendered as-is; falsy values hide the badge. */
+  badge?: string | number;
+};
+
+type Props<T extends string> = {
+  value: T;
+  options: readonly SegmentOption<T>[];
+  onChange: (value: T) => void;
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Pill-style segmented control. Selected segment uses inverse tone, others muted.
+ * 2+ options supported; sized to fill its container with equal-width segments.
+ */
+export const SegmentedControl = <T extends string>({
+  value,
+  options,
+  onChange,
+  style,
+}: Props<T>) => {
+  return (
+    <View style={[wrapper, style]} accessibilityRole="tablist">
+      {options.map((opt) => {
+        const selected = opt.value === value;
+        return (
+          <Pressable
+            key={opt.value}
+            accessibilityRole="tab"
+            accessibilityState={{ selected }}
+            accessibilityLabel={
+              opt.badge !== undefined && opt.badge !== ''
+                ? `${opt.label} (${opt.badge})`
+                : opt.label
+            }
+            onPress={() => {
+              if (!selected) onChange(opt.value);
+            }}
+            style={({ pressed }) => [
+              segment,
+              selected ? segmentSelected : segmentUnselected,
+              pressed && { opacity: 0.7 },
+            ]}
+          >
+            <Text
+              style={[label, { color: selected ? colors.textInverse : colors.textMuted }]}
+              numberOfLines={1}
+            >
+              {opt.label}
+            </Text>
+            {opt.badge !== undefined && opt.badge !== '' && (
+              <Text
+                style={[badge, { color: selected ? colors.textInverse : colors.textMuted }]}
+                numberOfLines={1}
+              >
+                {opt.badge}
+              </Text>
+            )}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
+
+const wrapper: ViewStyle = {
+  flexDirection: 'row',
+  backgroundColor: colors.surface,
+  borderRadius: radii.lg,
+  padding: 2,
+  gap: 2,
+};
+
+const segment: ViewStyle = {
+  flex: 1,
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: space.xs,
+  paddingVertical: space.sm,
+  paddingHorizontal: space.md,
+  borderRadius: radii.md,
+};
+
+const segmentSelected: ViewStyle = {
+  backgroundColor: colors.bgInverse,
+};
+
+const segmentUnselected: ViewStyle = {
+  backgroundColor: 'transparent',
+};
+
+const label = {
+  fontSize: font.size.sm,
+  fontWeight: font.weight.semibold,
+} as const;
+
+const badge = {
+  fontSize: font.size.xs,
+  fontWeight: font.weight.medium,
+  opacity: 0.85,
+} as const;

--- a/packages/app/src/components/StatCard.tsx
+++ b/packages/app/src/components/StatCard.tsx
@@ -1,4 +1,4 @@
-import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Pressable, Text, View, type StyleProp, type ViewStyle } from 'react-native';
 import { colors, font, radii, space } from '../theme';
 
 type Props = {
@@ -10,18 +10,47 @@ type Props = {
   subtext?: string;
   /** Optional accent color applied to the title text and border. */
   tone?: 'default' | 'warning' | 'good';
+  /** When provided, the card becomes pressable and shows a chevron affordance. */
+  onPress?: () => void;
   style?: StyleProp<ViewStyle>;
 };
 
-export const StatCard = ({ title, value, subtext, tone = 'default', style }: Props) => {
+export const StatCard = ({ title, value, subtext, tone = 'default', onPress, style }: Props) => {
   const accent = tone === 'warning' ? colors.warning : tone === 'good' ? colors.same : colors.text;
-  return (
-    <View style={[card, { borderColor: tone === 'default' ? colors.border : accent }, style]}>
-      <Text style={[titleStyle, { color: tone === 'default' ? colors.textMuted : accent }]}>
-        {title}
-      </Text>
+  const inner = (
+    <>
+      <View style={titleRow}>
+        <Text style={[titleStyle, { color: tone === 'default' ? colors.textMuted : accent }]}>
+          {title}
+        </Text>
+        {onPress && <Text style={chevron}>›</Text>}
+      </View>
       <Text style={valueStyle}>{value}</Text>
       {subtext !== undefined && subtext !== '' && <Text style={subtextStyle}>{subtext}</Text>}
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${title} ${value}`}
+        onPress={onPress}
+        style={({ pressed }) => [
+          card,
+          { borderColor: tone === 'default' ? colors.border : accent },
+          pressed && { opacity: 0.7 },
+          style,
+        ]}
+      >
+        {inner}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={[card, { borderColor: tone === 'default' ? colors.border : accent }, style]}>
+      {inner}
     </View>
   );
 };
@@ -36,11 +65,24 @@ const card: ViewStyle = {
   gap: space.xs,
 };
 
+const titleRow: ViewStyle = {
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: space.xs,
+};
+
 const titleStyle = {
   fontSize: font.size.xs,
   fontWeight: font.weight.semibold,
   letterSpacing: 0.5,
   textTransform: 'uppercase' as const,
+} as const;
+
+const chevron = {
+  fontSize: font.size.md,
+  color: colors.textMuted,
+  fontWeight: font.weight.bold,
 } as const;
 
 const valueStyle = {

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -5,6 +5,8 @@ export { Picker } from './Picker';
 export type { PickerOption } from './Picker';
 export { Chip } from './Chip';
 export type { ChipTone } from './Chip';
+export { SegmentedControl } from './SegmentedControl';
+export type { SegmentOption } from './SegmentedControl';
 export { EmptyState } from './EmptyState';
 export { ItemCard } from './ItemCard';
 export { MeasurementInputGroup } from './MeasurementInputGroup';

--- a/packages/app/src/repositories/index.ts
+++ b/packages/app/src/repositories/index.ts
@@ -1,5 +1,12 @@
 export { itemRepository } from './itemRepository';
-export type { ItemFilter, ItemSort } from './itemRepository';
+export type { ItemFilter, ItemSort, SoldFilter } from './itemRepository';
+export {
+  compareSoldByRecoveryRateDesc,
+  compareSoldByNetCpwAsc,
+  computeRecoveryRate,
+  passesRecoveryRateBounds,
+} from './soldHelpers';
+export type { SoldItem } from './soldHelpers';
 export { measurementRepository } from './measurementRepository';
 export { photoRepository } from './photoRepository';
 export { fitAnchorRepository } from './fitAnchorRepository';

--- a/packages/app/src/repositories/itemRepository.sold.test.ts
+++ b/packages/app/src/repositories/itemRepository.sold.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { GarmentItem, SaleInfo } from '@seam/shared';
+import {
+  compareSoldByNetCpwAsc,
+  compareSoldByRecoveryRateDesc,
+  computeRecoveryRate,
+  passesRecoveryRateBounds,
+  type SoldItem,
+} from './soldHelpers';
+
+const baseSold = (overrides: Partial<SoldItem>): SoldItem => {
+  const item: GarmentItem = {
+    id: overrides.id ?? 'i',
+    status: 'sold',
+    name: overrides.name ?? 'name',
+    category: overrides.category ?? 'shirt',
+    isFitAnchor: false,
+    isSellCandidate: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  } as GarmentItem;
+  const saleInfo: SaleInfo = overrides.saleInfo ?? { itemId: item.id };
+  return {
+    ...item,
+    saleInfo,
+    recoveryRate: overrides.recoveryRate,
+    netCpw: overrides.netCpw ?? null,
+    wearCount: overrides.wearCount ?? 0,
+  };
+};
+
+describe('compareSoldByRecoveryRateDesc', () => {
+  it('sorts higher recovery rate first', () => {
+    const items = [
+      baseSold({ id: 'low', recoveryRate: 0.3 }),
+      baseSold({ id: 'high', recoveryRate: 0.9 }),
+      baseSold({ id: 'mid', recoveryRate: 0.6 }),
+    ];
+    items.sort(compareSoldByRecoveryRateDesc);
+    expect(items.map((i) => i.id)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('places undefined recovery rate at the end', () => {
+    const items = [
+      baseSold({ id: 'undef', recoveryRate: undefined }),
+      baseSold({ id: 'mid', recoveryRate: 0.5 }),
+      baseSold({ id: 'high', recoveryRate: 0.9 }),
+    ];
+    items.sort(compareSoldByRecoveryRateDesc);
+    expect(items.map((i) => i.id)).toEqual(['high', 'mid', 'undef']);
+  });
+
+  it('treats two undefined as equal', () => {
+    const a = baseSold({ id: 'a', recoveryRate: undefined });
+    const b = baseSold({ id: 'b', recoveryRate: undefined });
+    expect(compareSoldByRecoveryRateDesc(a, b)).toBe(0);
+  });
+});
+
+describe('compareSoldByNetCpwAsc', () => {
+  it('sorts smaller netCpw first (= better deal)', () => {
+    const items = [
+      baseSold({ id: 'expensive', netCpw: 5000 }),
+      baseSold({ id: 'cheap', netCpw: 100 }),
+      baseSold({ id: 'mid', netCpw: 1500 }),
+    ];
+    items.sort(compareSoldByNetCpwAsc);
+    expect(items.map((i) => i.id)).toEqual(['cheap', 'mid', 'expensive']);
+  });
+
+  it('places null netCpw at the end', () => {
+    const items = [
+      baseSold({ id: 'null', netCpw: null }),
+      baseSold({ id: 'cheap', netCpw: 100 }),
+      baseSold({ id: 'mid', netCpw: 1500 }),
+    ];
+    items.sort(compareSoldByNetCpwAsc);
+    expect(items.map((i) => i.id)).toEqual(['cheap', 'mid', 'null']);
+  });
+
+  it('handles negative netCpw (profit per wear) as best', () => {
+    const items = [
+      baseSold({ id: 'normal', netCpw: 500 }),
+      baseSold({ id: 'profit', netCpw: -200 }),
+    ];
+    items.sort(compareSoldByNetCpwAsc);
+    expect(items.map((i) => i.id)).toEqual(['profit', 'normal']);
+  });
+});
+
+describe('computeRecoveryRate', () => {
+  it('returns soldPrice / totalPrice', () => {
+    expect(computeRecoveryRate(8000, 10000)).toBeCloseTo(0.8);
+  });
+
+  it('returns undefined when soldPrice is missing', () => {
+    expect(computeRecoveryRate(undefined, 10000)).toBeUndefined();
+  });
+
+  it('returns undefined when totalPrice is missing or non-positive', () => {
+    expect(computeRecoveryRate(5000, undefined)).toBeUndefined();
+    expect(computeRecoveryRate(5000, 0)).toBeUndefined();
+    expect(computeRecoveryRate(5000, -100)).toBeUndefined();
+  });
+
+  it('handles soldPrice > totalPrice (rate > 1) without clamping', () => {
+    expect(computeRecoveryRate(12000, 10000)).toBeCloseTo(1.2);
+  });
+});
+
+describe('passesRecoveryRateBounds', () => {
+  it('passes when no bounds are set', () => {
+    expect(passesRecoveryRateBounds({ recoveryRate: undefined })).toBe(true);
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.5 })).toBe(true);
+  });
+
+  it('rejects undefined recovery rate when any bound is set', () => {
+    expect(passesRecoveryRateBounds({ recoveryRate: undefined }, 0.3)).toBe(false);
+    expect(passesRecoveryRateBounds({ recoveryRate: undefined }, undefined, 0.8)).toBe(false);
+  });
+
+  it('applies inclusive lower bound', () => {
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.5 }, 0.5)).toBe(true);
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.49 }, 0.5)).toBe(false);
+  });
+
+  it('applies inclusive upper bound', () => {
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.8 }, undefined, 0.8)).toBe(true);
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.81 }, undefined, 0.8)).toBe(false);
+  });
+
+  it('combines both bounds', () => {
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.6 }, 0.5, 0.8)).toBe(true);
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.4 }, 0.5, 0.8)).toBe(false);
+    expect(passesRecoveryRateBounds({ recoveryRate: 0.9 }, 0.5, 0.8)).toBe(false);
+  });
+});

--- a/packages/app/src/repositories/itemRepository.ts
+++ b/packages/app/src/repositories/itemRepository.ts
@@ -143,10 +143,7 @@ export const itemRepository = {
    * `recoveryRate_desc` and `netCpw_asc` are sorted in JS (require non-trivial computation).
    * `recoveryRateMin/Max` filtering is also applied in JS for the same reason.
    */
-  async listSold(
-    filter: SoldFilter = {},
-    sort: ItemSort = 'soldAt_desc',
-  ): Promise<SoldItem[]> {
+  async listSold(filter: SoldFilter = {}, sort: ItemSort = 'soldAt_desc'): Promise<SoldItem[]> {
     const conditions: SQL[] = [eq(schema.items.status, 'sold')];
     if (filter.categories && filter.categories.length > 0) {
       conditions.push(inArray(schema.items.category, filter.categories as string[]));

--- a/packages/app/src/repositories/itemRepository.ts
+++ b/packages/app/src/repositories/itemRepository.ts
@@ -1,9 +1,18 @@
-import { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, like, or, sql, type SQL } from 'drizzle-orm';
 import { db, schema } from '../db/client';
 import { newId } from '../utils/ids';
 import { nowIso } from '../utils/dates';
-import type { GarmentItem, ItemStatus } from '@seam/shared';
+import type { GarmentItem, ItemStatus, SaleInfo } from '@seam/shared';
 import { CANDIDATE_STATUSES } from '@seam/shared';
+import { calculateNetCostPerWear } from '@seam/domain';
+import { wearLogRepository } from './wearLogRepository';
+import {
+  compareSoldByNetCpwAsc,
+  compareSoldByRecoveryRateDesc,
+  computeRecoveryRate,
+  passesRecoveryRateBounds,
+  type SoldItem,
+} from './soldHelpers';
 
 export type ItemRow = typeof schema.items.$inferSelect;
 
@@ -44,7 +53,26 @@ export type ItemSort =
   | 'purchasePrice_desc'
   | 'favoriteScore_desc'
   | 'category_asc'
-  | 'brand_asc';
+  | 'brand_asc'
+  | 'soldAt_desc'
+  | 'soldAt_asc'
+  | 'recoveryRate_desc'
+  | 'netCpw_asc';
+
+export type SoldFilter = {
+  categories?: readonly GarmentItem['category'][];
+  brand?: string;
+  search?: string;
+  /** ISO date string. Inclusive lower bound on sale_infos.soldAt. */
+  soldAtFrom?: string;
+  /** ISO date string. Exclusive upper bound on sale_infos.soldAt. */
+  soldAtTo?: string;
+  /** 0..1+ — recoveryRate = soldPrice / totalPrice. */
+  recoveryRateMin?: number;
+  recoveryRateMax?: number;
+};
+
+export type { SoldItem } from './soldHelpers';
 
 const orderByFor = (sort: ItemSort) => {
   switch (sort) {
@@ -57,15 +85,20 @@ const orderByFor = (sort: ItemSort) => {
     case 'favoriteScore_desc':
       return desc(schema.items.favoriteScore);
     case 'category_asc':
-      return schema.items.category;
+      return asc(schema.items.category);
     case 'brand_asc':
-      return schema.items.brand;
+      return asc(schema.items.brand);
+    case 'soldAt_desc':
+    case 'soldAt_asc':
+    case 'recoveryRate_desc':
+    case 'netCpw_asc':
+      return desc(schema.items.createdAt);
   }
 };
 
 export const itemRepository = {
   async list(filter: ItemFilter = {}, sort: ItemSort = 'createdAt_desc'): Promise<GarmentItem[]> {
-    const conditions = [];
+    const conditions: SQL[] = [];
     if (filter.statuses && filter.statuses.length > 0) {
       conditions.push(inArray(schema.items.status, filter.statuses as string[]));
     }
@@ -83,15 +116,14 @@ export const itemRepository = {
     }
     if (filter.search) {
       const q = `%${filter.search}%`;
-      conditions.push(
-        or(
-          like(schema.items.name, q),
-          like(schema.items.brand, q),
-          like(schema.items.modelName, q),
-          like(schema.items.notes, q),
-          like(schema.items.color, q),
-        ),
+      const searchOr = or(
+        like(schema.items.name, q),
+        like(schema.items.brand, q),
+        like(schema.items.modelName, q),
+        like(schema.items.notes, q),
+        like(schema.items.color, q),
       );
+      if (searchOr) conditions.push(searchOr);
     }
     const where = conditions.length > 0 ? and(...conditions) : undefined;
     const rows = await db.select().from(schema.items).where(where).orderBy(orderByFor(sort));
@@ -104,6 +136,109 @@ export const itemRepository = {
 
   async listOwned(): Promise<GarmentItem[]> {
     return this.list({ statuses: ['owned'] });
+  },
+
+  /**
+   * List sold items with their SaleInfo, derived recoveryRate / netCpw, and wear counts.
+   * `recoveryRate_desc` and `netCpw_asc` are sorted in JS (require non-trivial computation).
+   * `recoveryRateMin/Max` filtering is also applied in JS for the same reason.
+   */
+  async listSold(
+    filter: SoldFilter = {},
+    sort: ItemSort = 'soldAt_desc',
+  ): Promise<SoldItem[]> {
+    const conditions: SQL[] = [eq(schema.items.status, 'sold')];
+    if (filter.categories && filter.categories.length > 0) {
+      conditions.push(inArray(schema.items.category, filter.categories as string[]));
+    }
+    if (filter.brand) {
+      conditions.push(eq(schema.items.brand, filter.brand));
+    }
+    if (filter.search) {
+      const q = `%${filter.search}%`;
+      const searchOr = or(
+        like(schema.items.name, q),
+        like(schema.items.brand, q),
+        like(schema.items.modelName, q),
+        like(schema.items.notes, q),
+        like(schema.items.color, q),
+        like(schema.saleInfos.notes, q),
+      );
+      if (searchOr) conditions.push(searchOr);
+    }
+    if (filter.soldAtFrom) {
+      conditions.push(sql`${schema.saleInfos.soldAt} >= ${filter.soldAtFrom}`);
+    }
+    if (filter.soldAtTo) {
+      conditions.push(sql`${schema.saleInfos.soldAt} < ${filter.soldAtTo}`);
+    }
+
+    const where = and(...conditions);
+
+    const sqlOrderBy = (() => {
+      switch (sort) {
+        case 'soldAt_desc':
+          return desc(schema.saleInfos.soldAt);
+        case 'soldAt_asc':
+          return asc(schema.saleInfos.soldAt);
+        case 'createdAt_desc':
+          return desc(schema.items.createdAt);
+        case 'purchaseDate_desc':
+          return desc(schema.items.purchaseDate);
+        case 'purchasePrice_desc':
+          return desc(schema.items.purchasePrice);
+        case 'favoriteScore_desc':
+          return desc(schema.items.favoriteScore);
+        case 'category_asc':
+          return asc(schema.items.category);
+        case 'brand_asc':
+          return asc(schema.items.brand);
+        case 'recoveryRate_desc':
+        case 'netCpw_asc':
+          return desc(schema.saleInfos.soldAt);
+      }
+    })();
+
+    const rows = await db
+      .select({ item: schema.items, sale: schema.saleInfos })
+      .from(schema.items)
+      .leftJoin(schema.saleInfos, eq(schema.saleInfos.itemId, schema.items.id))
+      .where(where)
+      .orderBy(sqlOrderBy);
+
+    const itemIds = rows.map((r) => r.item.id);
+    const wearCounts = await wearLogRepository.countsByItems(itemIds);
+
+    const enriched: SoldItem[] = rows.map((r) => {
+      const item = toGarmentItem(r.item);
+      const sale = r.sale;
+      const saleInfo: SaleInfo = sale
+        ? {
+            itemId: sale.itemId,
+            soldPrice: sale.soldPrice ?? undefined,
+            soldAt: sale.soldAt ?? undefined,
+            soldSource: sale.soldSource ?? undefined,
+            notes: sale.notes ?? undefined,
+          }
+        : { itemId: item.id };
+      const wearCount = wearCounts[item.id] ?? 0;
+      const totalPrice = item.totalPrice ?? item.purchasePrice;
+      const recoveryRate = computeRecoveryRate(saleInfo.soldPrice, totalPrice);
+      const netCpw = calculateNetCostPerWear(totalPrice, wearCount, saleInfo.soldPrice);
+      return { ...item, saleInfo, recoveryRate, netCpw, wearCount };
+    });
+
+    const filtered = enriched.filter((it) =>
+      passesRecoveryRateBounds(it, filter.recoveryRateMin, filter.recoveryRateMax),
+    );
+
+    if (sort === 'recoveryRate_desc') {
+      filtered.sort(compareSoldByRecoveryRateDesc);
+    } else if (sort === 'netCpw_asc') {
+      filtered.sort(compareSoldByNetCpwAsc);
+    }
+
+    return filtered;
   },
 
   async getById(id: string): Promise<GarmentItem | null> {

--- a/packages/app/src/repositories/soldHelpers.ts
+++ b/packages/app/src/repositories/soldHelpers.ts
@@ -1,0 +1,70 @@
+import type { GarmentItem, SaleInfo } from '@seam/shared';
+
+/**
+ * Item enriched with the sold-context derived metrics. Returned by `itemRepository.listSold`.
+ * `recoveryRate` is undefined when soldPrice or totalPrice is missing/zero.
+ * `netCpw` is null when the calculation cannot be performed (e.g. wearCount === 0).
+ */
+export type SoldItem = GarmentItem & {
+  saleInfo: SaleInfo;
+  recoveryRate?: number;
+  netCpw: number | null;
+  wearCount: number;
+};
+
+export const computeRecoveryRate = (
+  soldPrice: number | undefined,
+  totalPrice: number | undefined,
+): number | undefined => {
+  if (typeof soldPrice !== 'number' || !Number.isFinite(soldPrice)) return undefined;
+  if (typeof totalPrice !== 'number' || !Number.isFinite(totalPrice) || totalPrice <= 0) {
+    return undefined;
+  }
+  return soldPrice / totalPrice;
+};
+
+/**
+ * Comparator for `recoveryRate_desc`. Items missing recoveryRate sort to the end.
+ */
+export const compareSoldByRecoveryRateDesc = (
+  a: Pick<SoldItem, 'recoveryRate'>,
+  b: Pick<SoldItem, 'recoveryRate'>,
+): number => {
+  const ar = a.recoveryRate;
+  const br = b.recoveryRate;
+  if (ar === undefined && br === undefined) return 0;
+  if (ar === undefined) return 1;
+  if (br === undefined) return -1;
+  return br - ar;
+};
+
+/**
+ * Comparator for `netCpw_asc`. Items with null netCpw sort to the end.
+ */
+export const compareSoldByNetCpwAsc = (
+  a: Pick<SoldItem, 'netCpw'>,
+  b: Pick<SoldItem, 'netCpw'>,
+): number => {
+  const an = a.netCpw;
+  const bn = b.netCpw;
+  if (an === null && bn === null) return 0;
+  if (an === null) return 1;
+  if (bn === null) return -1;
+  return an - bn;
+};
+
+/**
+ * Filter sold items by recoveryRate range. Items missing recoveryRate are
+ * excluded when either bound is set.
+ */
+export const passesRecoveryRateBounds = (
+  it: Pick<SoldItem, 'recoveryRate'>,
+  min?: number,
+  max?: number,
+): boolean => {
+  if (min === undefined && max === undefined) return true;
+  if (it.recoveryRate === undefined) return false;
+  if (min !== undefined && it.recoveryRate < min) return false;
+  if (max !== undefined && it.recoveryRate > max) return false;
+  return true;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.13
         version: 2.4.13
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
       turbo:
         specifier: 2.9.6
         version: 2.9.6
@@ -3998,6 +4001,60 @@ packages:
 
   lan-network@0.1.7:
     resolution: {integrity: sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==}
+    hasBin: true
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
   leven@3.1.0:
@@ -9715,6 +9772,49 @@ snapshots:
   kleur@3.0.3: {}
 
   lan-network@0.1.7: {}
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   leven@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 7.29.2
       '@hookform/resolvers':
         specifier: ^3.9.1
-        version: 3.10.0(react-hook-form@7.74.0(react@19.1.6))
+        version: 3.10.0(react-hook-form@7.74.0(react@19.1.0))
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
-        version: 2.2.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
+        version: 2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       '@seam/domain':
         specifier: workspace:*
         version: link:../domain
@@ -40,22 +40,22 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.45.0
-        version: 0.45.2(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))
+        version: 0.45.2(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       expo:
         specifier: ~54.0.33
-        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application:
         specifier: ~7.0.8
         version: 7.0.8(expo@54.0.33)
       expo-constants:
         specifier: ~18.0.13
-        version: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
+        version: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-document-picker:
         specifier: ~14.0.8
         version: 14.0.8(expo@54.0.33)
       expo-file-system:
         specifier: ~19.0.21
-        version: 19.0.21(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
+        version: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-image-manipulator:
         specifier: ~14.0.8
         version: 14.0.8(expo@54.0.33)
@@ -64,13 +64,13 @@ importers:
         version: 17.0.10(expo@54.0.33)
       expo-linking:
         specifier: ~8.0.11
-        version: 8.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-notifications:
         specifier: ~0.32.16
-        version: 0.32.16(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+        version: 0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(8b7908ef6c347c2f09edbf811693be36)
+        version: 6.0.23(4f5be0f4f2fe3cf8d6efca96a6d3c8db)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -79,31 +79,31 @@ importers:
         version: 14.0.8(expo@54.0.33)
       expo-sqlite:
         specifier: ~16.0.10
-        version: 16.0.10(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-status-bar:
         specifier: ~3.0.9
-        version: 3.0.9(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react:
-        specifier: 19.1.6
-        version: 19.1.6
+        specifier: 19.1.0
+        version: 19.1.0
       react-hook-form:
         specifier: ^7.54.0
-        version: 7.74.0(react@19.1.6)
+        version: 7.74.0(react@19.1.0)
       react-native:
-        specifier: 0.81.6
-        version: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+        specifier: 0.81.5
+        version: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
-        version: 2.28.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-reanimated:
         specifier: ~4.1.7
-        version: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-safe-area-context:
         specifier: 5.6.2
-        version: 5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-screens:
         specifier: ~4.16.0
-        version: 4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+        version: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -124,8 +124,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       eslint-config-expo:
-        specifier: ^55.0.0
-        version: 55.0.0(eslint@9.39.4)(typescript@5.9.3)
+        specifier: ^10.0.0
+        version: 10.0.0(eslint@9.39.4)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1849,8 +1849,8 @@ packages:
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
 
-  '@react-native/assets-registry@0.81.6':
-    resolution: {integrity: sha512-nNlJ7mdXFoq/7LMG3eJIncqjgXkpDJak3xO8Lb4yQmFI3XVI1nupPRjlYRY0ham1gLE0F/AWvKFChsKUfF5lOQ==}
+  '@react-native/assets-registry@0.81.5':
+    resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
     engines: {node: '>= 20.19.4'}
 
   '@react-native/babel-plugin-codegen@0.81.5':
@@ -1879,20 +1879,14 @@ packages:
     peerDependencies:
       '@babel/core': '*'
 
-  '@react-native/codegen@0.81.6':
-    resolution: {integrity: sha512-9KoYRep/KDnELLLmIYTtIIEOClVUJ88pxWObb/0sjkacA7uL4SgfbAg7rWLURAQJWI85L1YS67IhdEqNNk1I7w==}
-    engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
-
   '@react-native/codegen@0.85.2':
     resolution: {integrity: sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     peerDependencies:
       '@babel/core': '*'
 
-  '@react-native/community-cli-plugin@0.81.6':
-    resolution: {integrity: sha512-oTwIheF4TU7NkfoHxwSQAKtIDx4SQEs2xufgM3gguY7WkpnhGa/BYA/A+hdHXfqEKJFKlHcXQu4BrV/7Sv1fhw==}
+  '@react-native/community-cli-plugin@0.81.5':
+    resolution: {integrity: sha512-yWRlmEOtcyvSZ4+OvqPabt+NS36vg0K/WADTQLhrYrm9qdZSuXmq8PmdJWz/68wAqKQ+4KTILiq2kjRQwnyhQw==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@react-native-community/cli': '*'
@@ -1907,24 +1901,16 @@ packages:
     resolution: {integrity: sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w==}
     engines: {node: '>= 20.19.4'}
 
-  '@react-native/debugger-frontend@0.81.6':
-    resolution: {integrity: sha512-aGw28yzbtm25GQuuxNeVAT72tLuGoH0yh79uYOIZkvjI+5x1NjZyPrgiLZ2LlZi5dJdxfbz30p1zUcHvcAzEZw==}
-    engines: {node: '>= 20.19.4'}
-
   '@react-native/dev-middleware@0.81.5':
     resolution: {integrity: sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA==}
     engines: {node: '>= 20.19.4'}
 
-  '@react-native/dev-middleware@0.81.6':
-    resolution: {integrity: sha512-mK2M3gJ25LtgtqxS1ZXe1vHrz8APOA79Ot/MpbLeovFgLu6YJki0kbO5MRpJagTd+HbesVYSZb/BhAsGN7QAXA==}
+  '@react-native/gradle-plugin@0.81.5':
+    resolution: {integrity: sha512-hORRlNBj+ReNMLo9jme3yQ6JQf4GZpVEBLxmTXGGlIL78MAezDZr5/uq9dwElSbcGmLEgeiax6e174Fie6qPLg==}
     engines: {node: '>= 20.19.4'}
 
-  '@react-native/gradle-plugin@0.81.6':
-    resolution: {integrity: sha512-atUItC5MZ6yaNaI0sbsoDwUdF+KMNZcMKBIrNhXlUyIj3x1AQ6Cf8CHHv6Qokn8ZFw+uU6GWmQSiOWYUbmi8Ag==}
-    engines: {node: '>= 20.19.4'}
-
-  '@react-native/js-polyfills@0.81.6':
-    resolution: {integrity: sha512-P5MWH/9vM24XkJ1TasCq42DMLoCUjZVSppTn6VWv/cI65NDjuYEy7bUSaXbYxGTnqiKyPG5Y+ADymqlIkdSAcw==}
+  '@react-native/js-polyfills@0.81.5':
+    resolution: {integrity: sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w==}
     engines: {node: '>= 20.19.4'}
 
   '@react-native/js-polyfills@0.85.2':
@@ -1944,14 +1930,11 @@ packages:
   '@react-native/normalize-colors@0.81.5':
     resolution: {integrity: sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==}
 
-  '@react-native/normalize-colors@0.81.6':
-    resolution: {integrity: sha512-/OCgUysHIFhfmZxbJAydVc58l2SGIZbWpbQXBrYEYch8YElBbDFQ8IUtyogB7YJJQ8ewHZFj93rQGaECgkvvcw==}
-
-  '@react-native/virtualized-lists@0.81.6':
-    resolution: {integrity: sha512-1RrZl3a7iCoAS2SGaRLjJPIn8bg/GLNXzqkIB2lufXcJsftu1umNLRIi17ZoDRejAWSd2pUfUtQBASo4R2mw4Q==}
+  '@react-native/virtualized-lists@0.81.5':
+    resolution: {integrity: sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
-      '@types/react': ^19.1.4
+      '@types/react': ^19.1.0
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -3184,8 +3167,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-expo@55.0.0:
-    resolution: {integrity: sha512-YvhaKrp1g7pR/qjdI12E5nw9y0DJZWgYr815vyW8wskGLsFvxATY3mtKL8zm3ZYzWj3Bvc37tRIS661TEkrv9A==}
+  eslint-config-expo@10.0.0:
+    resolution: {integrity: sha512-/XC/DvniUWTzU7Ypb/cLDhDD4DXqEio4lug1ObD/oQ9Hcx3OVOR8Mkp4u6U4iGoZSJyIQmIk3WVHe/P1NYUXKw==}
     peerDependencies:
       eslint: '>=8.10'
 
@@ -4721,13 +4704,13 @@ packages:
       react: '*'
       react-native: 0.81 - 0.85
 
-  react-native@0.81.6:
-    resolution: {integrity: sha512-X/tI8GqfzVaa+zfbE4+lySNN5UzwBIAVRHVZPKymOny9Acc5GYYcjAcEVfG3AM4h920YALWoSl8favnDmQEWIg==}
+  react-native@0.81.5:
+    resolution: {integrity: sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==}
     engines: {node: '>= 20.19.4'}
     hasBin: true
     peerDependencies:
-      '@types/react': ^19.1.4
-      react: ^19.1.4
+      '@types/react': ^19.1.0
+      react: ^19.1.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4766,8 +4749,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.1.6:
-    resolution: {integrity: sha512-GVXa6S2mNw6QQg1KZRnX7fB/3F5sEy+7nsL8IrrlOLDxKXyfR97ZP3hNvWidFy1YkJlUvMYpeqUFxwY1ez6h3A==}
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
   reflect.getprototypeof@1.0.10:
@@ -6593,7 +6576,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(typescript@5.9.3)':
+  '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.2.0
       '@expo/code-signing-certificates': 0.0.6
@@ -6627,7 +6610,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.5
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -6660,8 +6643,8 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      expo-router: 6.0.23(8b7908ef6c347c2f09edbf811693be36)
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo-router: 6.0.23(4f5be0f4f2fe3cf8d6efca96a6d3c8db)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -6719,12 +6702,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@0.1.8(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   '@expo/env@2.0.11':
     dependencies:
@@ -6794,23 +6777,23 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       anser: 1.4.10
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       pretty-format: 29.7.0
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.6)
+      react-dom: 19.1.0(react@19.1.0)
 
   '@expo/metro@54.2.0':
     dependencies:
@@ -6861,7 +6844,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -6889,11 +6872,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -6903,9 +6886,9 @@ snapshots:
       chalk: 4.1.2
       js-yaml: 4.1.1
 
-  '@hookform/resolvers@3.10.0(react-hook-form@7.74.0(react@19.1.6))':
+  '@hookform/resolvers@3.10.0(react-hook-form@7.74.0(react@19.1.0))':
     dependencies:
-      react-hook-form: 7.74.0(react@19.1.6)
+      react-hook-form: 7.74.0(react@19.1.0)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7047,202 +7030,202 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-collection@1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
+  '@radix-ui/react-collection@1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-dialog@1.1.15(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
+  '@radix-ui/react-dialog@1.1.15(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.0)
       aria-hidden: 1.2.6
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-      react-remove-scroll: 2.7.2(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.17)(react@19.1.6)':
-    dependencies:
-      react: 19.1.6
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-id@1.1.1(@types/react@19.1.17)(react@19.1.6)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-portal@1.1.9(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-presence@1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-primitive@2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
-    optionalDependencies:
-      '@types/react': 19.1.17
-
-  '@radix-ui/react-roving-focus@1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-slot@1.2.0(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-tabs@1.1.13(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-portal@1.1.9(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-presence@1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-primitive@2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
+      '@radix-ui/react-collection': 1.1.7(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-slot@1.2.0(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      react: 19.1.6
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-tabs@1.1.13(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.6)
-      react: 19.1.6
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.17)(react@19.1.6)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.17)(react@19.1.0)':
     dependencies:
-      react: 19.1.6
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  '@react-native/assets-registry@0.81.6': {}
+  '@react-native/assets-registry@0.81.5': {}
 
   '@react-native/babel-plugin-codegen@0.81.5(@babel/core@7.29.0)':
     dependencies:
@@ -7358,16 +7341,6 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/codegen@0.81.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
-      glob: 7.2.3
-      hermes-parser: 0.29.1
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      yargs: 17.7.2
-
   '@react-native/codegen@0.85.2(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -7378,9 +7351,9 @@ snapshots:
       tinyglobby: 0.2.16
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.81.6(@react-native/metro-config@0.85.2(@babel/core@7.29.0))':
+  '@react-native/community-cli-plugin@0.81.5(@react-native/metro-config@0.85.2(@babel/core@7.29.0))':
     dependencies:
-      '@react-native/dev-middleware': 0.81.6
+      '@react-native/dev-middleware': 0.81.5
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3
@@ -7395,8 +7368,6 @@ snapshots:
       - utf-8-validate
 
   '@react-native/debugger-frontend@0.81.5': {}
-
-  '@react-native/debugger-frontend@0.81.6': {}
 
   '@react-native/dev-middleware@0.81.5':
     dependencies:
@@ -7416,27 +7387,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/dev-middleware@0.81.6':
-    dependencies:
-      '@isaacs/ttlcache': 1.4.1
-      '@react-native/debugger-frontend': 0.81.6
-      chrome-launcher: 0.15.2
-      chromium-edge-launcher: 0.2.0
-      connect: 3.7.0
-      debug: 4.4.3
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      open: 7.4.2
-      serve-static: 1.16.3
-      ws: 6.2.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
+  '@react-native/gradle-plugin@0.81.5': {}
 
-  '@react-native/gradle-plugin@0.81.6': {}
-
-  '@react-native/js-polyfills@0.81.6': {}
+  '@react-native/js-polyfills@0.81.5': {}
 
   '@react-native/js-polyfills@0.85.2': {}
 
@@ -7463,75 +7416,73 @@ snapshots:
 
   '@react-native/normalize-colors@0.81.5': {}
 
-  '@react-native/normalize-colors@0.81.6': {}
-
-  '@react-native/virtualized-lists@0.81.6(@types/react@19.1.17)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@react-native/virtualized-lists@0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@react-navigation/bottom-tabs@7.15.10(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-screens@4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@react-navigation/bottom-tabs@7.15.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/elements': 2.9.15(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      '@react-navigation/native': 7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@react-navigation/elements': 2.9.15(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-screens: 4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/core@7.17.2(react@19.1.6)':
+  '@react-navigation/core@7.17.2(react@19.1.0)':
     dependencies:
       '@react-navigation/routers': 7.5.3
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       query-string: 7.1.3
-      react: 19.1.6
+      react: 19.1.0
       react-is: 19.2.5
-      use-latest-callback: 0.2.6(react@19.1.6)
-      use-sync-external-store: 1.6.0(react@19.1.6)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@react-navigation/elements@2.9.15(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@react-navigation/elements@2.9.15(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/native': 7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      use-latest-callback: 0.2.6(react@19.1.6)
-      use-sync-external-store: 1.6.0(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@react-navigation/native-stack@7.14.12(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-screens@4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@react-navigation/native-stack@7.14.12(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/elements': 2.9.15(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      '@react-navigation/native': 7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@react-navigation/elements': 2.9.15(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-screens: 4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)':
+  '@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/core': 7.17.2(react@19.1.6)
+      '@react-navigation/core': 7.17.2(react@19.1.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      use-latest-callback: 0.2.6(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      use-latest-callback: 0.2.6(react@19.1.0)
 
   '@react-navigation/routers@7.5.3':
     dependencies:
@@ -8217,7 +8168,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8538,9 +8489,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)):
+  drizzle-orm@0.45.2(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
     optionalDependencies:
-      expo-sqlite: 16.0.10(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      expo-sqlite: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8790,7 +8741,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-expo@55.0.0(eslint@9.39.4)(typescript@5.9.3):
+  eslint-config-expo@10.0.0(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
@@ -8987,69 +8938,69 @@ snapshots:
 
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3):
+  expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-constants@18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)):
+  expo-constants@18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
   expo-document-picker@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)):
+  expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-font@14.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   expo-image-loader@6.0.0(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-image-manipulator@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-image-loader: 6.0.0(expo@54.0.33)
 
   expo-image-picker@17.0.10(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-image-loader: 6.0.0(expo@54.0.33)
 
-  expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.6):
+  expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      react: 19.1.6
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
 
-  expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       invariant: 2.2.4
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -9062,64 +9013,64 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3):
+  expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
       '@ide/backoff': 1.0.0
       abort-controller: 3.0.0
       assert: 2.1.0
       badgin: 1.2.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application: 7.0.8(expo@54.0.33)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@6.0.23(8b7908ef6c347c2f09edbf811693be36):
+  expo-router@6.0.23(4f5be0f4f2fe3cf8d6efca96a6d3c8db):
     dependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
-      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.6)
-      '@radix-ui/react-tabs': 1.1.13(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      '@react-navigation/bottom-tabs': 7.15.10(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-screens@4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      '@react-navigation/native': 7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      '@react-navigation/native-stack': 7.14.12(@react-navigation/native@7.2.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native-screens@4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.15.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native-stack': 7.14.12(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
-      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.11
       query-string: 7.1.3
-      react: 19.1.6
+      react: 19.1.0
       react-fast-compare: 3.2.2
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-screens: 4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
-      use-latest-callback: 0.2.6(react@19.1.6)
-      vaul: 1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
+      use-latest-callback: 0.2.6(react@19.1.0)
+      vaul: 1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.6)
-      react-native-gesture-handler: 2.28.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-reanimated: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react-dom: 19.1.0(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -9128,54 +9079,54 @@ snapshots:
 
   expo-secure-store@15.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-server@1.0.5: {}
 
   expo-sharing@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       await-lock: 2.2.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-status-bar@3.0.9(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
-  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3):
+  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(typescript@5.9.3)
+      '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.4
       '@expo/metro': 54.2.0
       '@expo/metro-config': 54.0.14(expo@54.0.33)
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33)(react-refresh@0.14.2)
-      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
-      expo-file-system: 19.0.21(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))
-      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      expo-keep-awake: 15.0.8(expo@54.0.33)(react@19.1.6)
+      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-file-system: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.33)(react@19.1.0)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      expo-modules-core: 3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -10588,20 +10539,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-dom@19.1.0(react@19.1.6):
+  react-dom@19.1.0(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
       scheduler: 0.26.0
 
   react-fast-compare@3.2.2: {}
 
-  react-freeze@1.0.4(react@19.1.6):
+  react-freeze@1.0.4(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
 
-  react-hook-form@7.74.0(react@19.1.6):
+  react-hook-form@7.74.0(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
 
   react-is@16.13.1: {}
 
@@ -10609,41 +10560,41 @@ snapshots:
 
   react-is@19.2.5: {}
 
-  react-native-gesture-handler@2.28.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-reanimated@4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
-      react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       semver: 7.7.4
 
-  react-native-safe-area-context@5.6.2(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-screens@4.16.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-freeze: 1.0.4(react@19.1.6)
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      react: 19.1.0
+      react-freeze: 1.0.4(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
 
-  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6):
+  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -10657,22 +10608,22 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@react-native/metro-config': 0.85.2(@babel/core@7.29.0)
       convert-source-map: 2.0.0
-      react: 19.1.6
-      react-native: 0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6):
+  react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.81.6
-      '@react-native/codegen': 0.81.6(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.81.6(@react-native/metro-config@0.85.2(@babel/core@7.29.0))
-      '@react-native/gradle-plugin': 0.81.6
-      '@react-native/js-polyfills': 0.81.6
-      '@react-native/normalize-colors': 0.81.6
-      '@react-native/virtualized-lists': 0.81.6(@types/react@19.1.17)(react-native@0.81.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.6))(react@19.1.6)
+      '@react-native/assets-registry': 0.81.5
+      '@react-native/codegen': 0.81.5(@babel/core@7.29.0)
+      '@react-native/community-cli-plugin': 0.81.5(@react-native/metro-config@0.85.2(@babel/core@7.29.0))
+      '@react-native/gradle-plugin': 0.81.5
+      '@react-native/js-polyfills': 0.81.5
+      '@react-native/normalize-colors': 0.81.5
+      '@react-native/virtualized-lists': 0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -10690,7 +10641,7 @@ snapshots:
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
-      react: 19.1.6
+      react: 19.1.0
       react-devtools-core: 6.1.5
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
@@ -10712,34 +10663,34 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.1.17)(react@19.1.6):
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.17)(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
 
-  react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.6):
+  react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.0):
     dependencies:
-      react: 19.1.6
-      react-remove-scroll-bar: 2.3.8(@types/react@19.1.17)(react@19.1.6)
-      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.6)
+      react: 19.1.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.17)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.1.17)(react@19.1.6)
-      use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.6)
+      use-callback-ref: 1.3.3(@types/react@19.1.17)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
 
-  react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.6):
+  react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.1.6
+      react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
 
-  react@19.1.6: {}
+  react@19.1.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -11364,28 +11315,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.6):
+  use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
 
-  use-latest-callback@0.2.6(react@19.1.6):
+  use-latest-callback@0.2.6(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
 
-  use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.6):
+  use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.1.6
+      react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.17
 
-  use-sync-external-store@1.6.0(react@19.1.6):
+  use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
-      react: 19.1.6
+      react: 19.1.0
 
   util@0.12.5:
     dependencies:
@@ -11403,11 +11354,11 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul@1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6):
+  vaul@1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.6))(react@19.1.6)
-      react: 19.1.6
-      react-dom: 19.1.0(react@19.1.6)
+      '@radix-ui/react-dialog': 1.1.15(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,19 @@
   "reviewers": ["sugarshin"],
   "packageRules": [
     {
+      "description": "Group react / react-native and their type & community siblings into a single PR. react-native ships a renderer that must match the installed react version exactly; bumping them in separate PRs causes 'Incompatible React versions' crashes at app start. Renovate has no preset that crosses the react and react-native monorepos, so we group manually.",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "react-native",
+        "react-test-renderer",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "matchPackagePrefixes": ["@react-native/", "@react-native-community/"],
+      "groupName": "react + react-native"
+    },
+    {
       "description": "Constrain Expo SDK 54 managed peers — only bump these via an Expo SDK upgrade. Out-of-range updates break babel-preset-expo's bundled @react-native/codegen.",
       "matchPackageNames": ["react", "react-dom"],
       "allowedVersions": "<19.2.0"


### PR DESCRIPTION
## Summary

- **Closet を所有中 / 売却済みの2モードに**。SegmentedControl で切り替え、Sold モードでは売却年・回収率レンジの Picker と soldAt / recoveryRate / netCpw のソートを追加。Stats の「売却済み」カードからもドリルダウン可能にした。`plan/initial-plan.md` L840-848 の「sold item は Closet から除外 / **表示切替できる**」の表示切替側を実装。
- **Renovate を強化**して `react / react-native / @types/react / @react-native(/-community)/*` を 1 PR にまとめる。先日 react@19.1.6 と react-native@0.81.6 が別 PR で bump され renderer (19.1.4) と react が乖離して起動時クラッシュした問題への恒久対応。Renovate の公式 preset には react と react-native を横断するものがないため自前 packageRules を追加。
- **CI に `expo install --check`** を追加。Renovate のグループ化をすり抜けたずれを PR 時点で検出する。
- 現状のローカルを `npx expo install --fix` で揃え（react 19.1.6→19.1.0 / react-native 0.81.6→0.81.5 / eslint-config-expo 55→^10）。

## Design references

- `~/.claude/plans/sold-ux-glittery-whistle.md` に詳細プラン（推奨アプローチ、UI 構造、フィルタ/ソート軸、トレードオフ）。
- スコープ外（後続タスクとして切り出し）: Compare 画面の「過去 Sold と類似」、`findDuplicateClusters` の Sold 拡張、Item Detail からの Cross-link、販売元フィルタ。

## UX

```
[ Closet ]
┌─────────────────────────────────┐
│ [ 所有中(N) ] [ 売却済み(N) ]     │
├─────────────────────────────────┤
│ 🔍 検索    並び替え ▾            │
│ Sold時: [売却年▾][回収率▾]       │
│ [トップス][ボトムス][アウター]…    │
├─────────────────────────────────┤
│ 📷 Levi's 501                    │
│   売却 ¥8000  回収 80%           │
│   2026-03-12 · メルカリ          │
└─────────────────────────────────┘
```

- 検索 / カテゴリは両モードで保持。Anchor は Owned 専用なので Sold 切替時に自動解除。
- ソートはモードごとに別 state（Owned=createdAt_desc、Sold=soldAt_desc がデフォルト）。
- 件数バッジはフィルタ適用前の全体件数（切替判断材料を変動させないため）。
- Sold モードでは FAB 非表示、空状態は専用文言。

## Repository 層

- `repositories/soldHelpers.ts` を分離して `SoldItem` 型・純粋関数（`computeRecoveryRate`, comparators, range filter）を単体テスト可能に。
- `itemRepository.listSold(filter, sort)` で `items LEFT JOIN sale_infos`、`wearLogRepository.countsByItems` で wear count を一括取得。`recoveryRate` / `netCpw` 由来のソート・フィルタは JS 側で実施（年数十件規模で問題なし、1k 超で重くなったら再検討）。
- `search` の OR に `sale_infos.notes` を含める（売却メモは Sold 文脈で第一級情報）。
- `ItemSort` に `soldAt_desc | soldAt_asc | recoveryRate_desc | netCpw_asc` を追加。

## Test plan

- [x] `pnpm -r typecheck` 緑
- [x] `pnpm -r test` 緑（domain 144 + app 43、純粋関数 15 件のテスト追加済み）
- [x] `pnpm --filter @seam/app lint` 緑
- [x] `npx expo install --check` 揃い済み
- [ ] iOS シミュレータで Closet [所有中] [売却済み] 切替時に検索・カテゴリが保持されること
- [ ] Owned→Sold 切替時に Anchor フィルタが自動解除されること
- [ ] Sold モードで売却年フィルタ（2026 / 2025）と回収率レンジ（80% 以上 / 30% 未満）が機能すること
- [ ] 並び順: 売却日順 / 回収率順 / Net CPW 順それぞれで結果が期待通りに並ぶこと
- [ ] ItemCard の Sold 表示で売却日・回収率・販売元が出ること
- [ ] Stats の「売却済み」カードをタップすると Closet が sold モードで開くこと
- [ ] 0 件のときの EmptyState 表示
- [ ] Maestro 既存 flow（00_smoke / 10_create_item / 20_record_decision）にリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)