### PR TITLE
Improve Wishlist price/auction-end visibility

### DIFF
--- a/packages/app/app/(tabs)/wishlist.tsx
+++ b/packages/app/app/(tabs)/wishlist.tsx
@@ -26,6 +26,18 @@ import { Picker, type PickerOption } from '../../src/components/Picker';
 import { candidateInfoRepository, itemRepository, photoRepository } from '../../src/repositories';
 import { colors, font, radii, space } from '../../src/theme';
 
+const formatAuctionEnds = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso.replace('T', ' ').slice(0, 16);
+  }
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `〆 ${mm}/${dd} ${hh}:${mi}`;
+};
+
 type WishSort = 'auctionEndsAt_asc' | 'price_asc' | 'createdAt_desc';
 
 const SORT_OPTIONS: readonly PickerOption<WishSort>[] = [
@@ -126,19 +138,13 @@ export default function WishlistScreen() {
     const total = c?.totalPrice ?? c?.currentPrice;
     const ends = c?.auctionEndsAt;
     return (
-      <View style={cardWrap}>
-        <ItemCard
-          item={item.item}
-          thumbnailRelativePath={item.thumbnail}
-          onPress={() => router.push({ pathname: '/candidate/[id]', params: { id: item.item.id } })}
-        />
-        {(total !== undefined || ends !== undefined) && (
-          <View style={metaRow}>
-            {total !== undefined && <Text style={metaPrice}>¥{total.toLocaleString()}</Text>}
-            {ends && <Text style={metaEnds}>～ {ends.replace('T', ' ').slice(0, 16)}</Text>}
-          </View>
-        )}
-      </View>
+      <ItemCard
+        item={item.item}
+        thumbnailRelativePath={item.thumbnail}
+        priceLabel={total !== undefined ? `¥${total.toLocaleString()}` : undefined}
+        endsLabel={ends ? formatAuctionEnds(ends) : undefined}
+        onPress={() => router.push({ pathname: '/candidate/[id]', params: { id: item.item.id } })}
+      />
     );
   };
 
@@ -234,31 +240,6 @@ const chipScrollWrapper: ViewStyle = {
   borderBottomWidth: 1,
   borderBottomColor: colors.border,
 };
-
-const cardWrap: ViewStyle = {
-  borderBottomWidth: 1,
-  borderBottomColor: colors.border,
-};
-
-const metaRow: ViewStyle = {
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  paddingHorizontal: space.lg,
-  paddingBottom: space.sm,
-  marginTop: -space.xs,
-};
-
-const metaPrice = {
-  fontSize: font.size.md,
-  color: colors.text,
-  fontWeight: font.weight.bold,
-} as const;
-
-const metaEnds = {
-  fontSize: font.size.sm,
-  color: colors.textMuted,
-} as const;
 
 const fab: ViewStyle = {
   position: 'absolute',

--- a/packages/app/src/components/ItemCard.tsx
+++ b/packages/app/src/components/ItemCard.tsx
@@ -13,6 +13,10 @@ type Props = {
   saleInfo?: SaleInfo;
   /** soldPrice / totalPrice. Pass alongside `saleInfo` to render a recovery-rate chip. */
   recoveryRate?: number;
+  /** Right-aligned primary label, e.g. "¥4,000". Used on wishlist rows. */
+  priceLabel?: string;
+  /** Right-aligned secondary label below `priceLabel`, e.g. auction end time. */
+  endsLabel?: string;
   onPress?: () => void;
 };
 
@@ -42,6 +46,8 @@ export const ItemCard = ({
   wearCount,
   saleInfo,
   recoveryRate,
+  priceLabel,
+  endsLabel,
   onPress,
 }: Props) => {
   const isSold = item.status === 'sold';
@@ -107,6 +113,16 @@ export const ItemCard = ({
           )}
         </View>
       </View>
+      {(priceLabel !== undefined || endsLabel !== undefined) && (
+        <View style={priceBox}>
+          {priceLabel !== undefined && <Text style={priceText}>{priceLabel}</Text>}
+          {endsLabel !== undefined && (
+            <Text style={endsText} numberOfLines={1}>
+              {endsLabel}
+            </Text>
+          )}
+        </View>
+      )}
     </View>
   );
   if (onPress) {
@@ -185,3 +201,21 @@ const badgeRow: ViewStyle = {
   gap: space.xs,
   marginTop: space.xs,
 };
+
+const priceBox: ViewStyle = {
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  gap: space.xs,
+  marginLeft: space.sm,
+};
+
+const priceText = {
+  fontSize: font.size.lg,
+  fontWeight: font.weight.bold,
+  color: colors.text,
+} as const;
+
+const endsText = {
+  fontSize: font.size.xs,
+  color: colors.textMuted,
+} as const;


### PR DESCRIPTION
## Summary
- Wishlist の価格 (¥4,000) が `ItemCard` の bottom border 直下に表示され、行と切り離されて見える問題を修正
- `ItemCard` に `priceLabel` / `endsLabel` 任意 props を追加し、行右端に「太字の価格 + 補助テキストの締切」を縦並びで描画するスロットを用意
- `wishlist.tsx` 側で旧 `metaRow` と二重 border を生んでいた `cardWrap` を削除し、props 経由で渡すよう変更
- オークション締切表記を `2026-04-30 18:00` → `〆 04/30 18:00` に短縮し、行の右側に収まるよう調整

## Test plan
- [x] `pnpm --filter @seam/app typecheck`
- [x] `pnpm --filter @seam/app lint`
- [x] `pnpm format`
- [x] pre-push hook (`format-check` / `test` / `typecheck` / `lint`) 全 pass
- [ ] iOS Simulator で Wishlist タブを開き、価格と締切がカード行内に正しく表示されるか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)