### PR TITLE
ci: PR build check + release.yml use default Xcode 26.2 (no platform download)

### DIFF
--- a/.github/workflows/ios-build-check.yml
+++ b/.github/workflows/ios-build-check.yml
@@ -28,13 +28,12 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.2'
 
-      - name: Download iOS platform
-        run: |
-          set -euo pipefail
-          xcodebuild -downloadPlatform iOS
-          xcodebuild -showsdks
+      # 検証用: Xcode 26.2 (macos-26 default) なら iOS 26.2 device platform runtime が
+      # 同梱されているはず、という仮説を確認する。-showsdks でランナー初期状態を可視化。
+      - name: Show iOS platform info
+        run: xcodebuild -showsdks
 
       - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6
         with:

--- a/.github/workflows/ios-build-check.yml
+++ b/.github/workflows/ios-build-check.yml
@@ -1,0 +1,103 @@
+name: ios-build-check
+
+on:
+  pull_request:
+    paths:
+      - 'packages/app/package.json'
+      - 'packages/app/app.json'
+      - 'packages/app/scripts/stripPushEntitlement.mjs'
+      - 'pnpm-lock.yaml'
+      - '.npmrc'
+      - '.github/workflows/ios-build-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios-build:
+    name: iOS build (unsigned, no archive)
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: '26.0'
+
+      - name: Download iOS platform
+        run: |
+          set -euo pipefail
+          xcodebuild -downloadPlatform iOS
+          xcodebuild -showsdks
+
+      - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.9'
+          bundler-cache: false
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Expo prebuild
+        working-directory: packages/app
+        run: pnpm exec expo prebuild --platform ios --clean --no-install
+
+      - name: Strip push entitlement
+        working-directory: packages/app
+        run: node scripts/stripPushEntitlement.mjs
+
+      - name: Cache Pods
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            packages/app/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('pnpm-lock.yaml', 'packages/app/package.json', 'packages/app/app.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Pod install
+        working-directory: packages/app/ios
+        env:
+          RCT_NEW_ARCH_ENABLED: '1'
+          USE_HERMES: '1'
+        run: pod install --repo-update
+
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-${{ hashFiles('packages/app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-
+
+      - name: Build (unsigned, no archive)
+        working-directory: packages/app/ios
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace Seam.xcworkspace \
+            -scheme Seam \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            ENABLE_BITCODE=NO \
+            build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,28 +41,13 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.2'
 
-      - name: Cache iOS platform runtime
-        id: ios-platform-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/Library/Developer/CoreSimulator
-          key: ${{ runner.os }}-ios-platform-xcode-26.0-v1
-          restore-keys: |
-            ${{ runner.os }}-ios-platform-xcode-26.0-
-
-      - name: Download iOS platform
-        if: steps.ios-platform-cache.outputs.cache-hit != 'true'
-        run: xcodebuild -downloadPlatform iOS
-
+      # macos-26 default Xcode (26.2) には iOS 26.2 device platform runtime が同梱
+      # されているため、xcodebuild -downloadPlatform iOS は不要。ios-build-check.yml
+      # の検証 run で確認済み。-showsdks のみ残し、初期状態を可視化する。
       - name: Show iOS platform info
-        run: |
-          xcodebuild -showsdks
-          du -sh ~/Library/Developer/CoreSimulator 2>/dev/null || echo "no ~/Library/Developer/CoreSimulator"
-          ls -la ~/Library/Developer/CoreSimulator/Volumes 2>/dev/null || true
-          ls -la /Library/Developer/CoreSimulator/Volumes 2>/dev/null || true
+        run: xcodebuild -showsdks
 
       - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6
         with:


### PR DESCRIPTION
## Summary
- 新規 workflow \`ios-build-check.yml\` を追加。PR で native ビルドが壊れたかをコスパよく検知。\`xcodebuild build\`（archive 省略）で Swift / native コンパイル段階のエラーを最短検出。path filter で JS-only PR は素通り。
- \`release.yml\` を default Xcode 26.2 に切替、\`xcodebuild -downloadPlatform iOS\` と CoreSimulator cache を削除。multi-GB ダウンロード分の数分が毎リリース短縮される。

## Background

### ios-build-check
release.yml は tag push でしか走らないため、Expo SDK / RN / 設定変更で native build が壊れていても release タイミングまで気付けない問題があった (例: SDK 55 bump 時の Swift \`@MainActor\` エラー)。一方で全 PR に対する macOS build は時間コスト (queue 込み 5-10 分) が重いため、native に影響しうる入力が変わった PR でだけ走らせる。

### release.yml の Xcode 切替
当初 \`xcode-version: '26.0'\` (= 26.0.1 にresolve) で運用していて、macos-26 runner には iOS 26.0 device platform runtime が preinstall されていなかったため、commit dc986c8 で \`xcodebuild -downloadPlatform iOS\` を毎回実行する形になっていた (3950162 で CoreSimulator cache を追加)。

仮説: macos-26 default Xcode (26.2) には iOS 26.2 device platform runtime が同梱されている → download 不要になる。

検証: ios-build-check workflow を \`xcode-version: '26.2'\` + download step 無しで初回実行 → 9分44秒で SUCCESS (commit 0fd25eb)。release.yml にも同じ変更を反映。

## Path filter (ios-build-check)
監視対象（変更があった PR でだけ workflow が起動）:
- \`packages/app/package.json\` — RN / Expo SDK / native dep
- \`packages/app/app.json\` — bundleId, plugins, ios.* config
- \`packages/app/scripts/stripPushEntitlement.mjs\` — entitlements 操作
- \`pnpm-lock.yaml\` — transitive native dep / Renovate
- \`.npmrc\` — \`node-linker=hoisted\`（autolinking 前提）
- \`.github/workflows/ios-build-check.yml\` — workflow 自身

JS / TS / babel / metro 系の壊れは既存 \`test.yml\` の \`expo export\` がカバー済みのため二重検査せず、コスパ重視で外している。

## リスク / 既知の制約

- **release.yml の変更はこの PR では直接実行されない** (tag push でしか走らないため)。ios-build-check が \`xcodebuild build\` で同じ runner / Xcode / SDK を使って通った事実があるため archive (= build + post-processing) もほぼ確実に通る想定だが、初回 release tag push 時にもし失敗したら revert (download step 復活) してください。
- branch protection で required にする場合は path filter のままだと JS-only PR で pending になる点に注意（必要なら別途 sentinel job 追加）。

## Test plan
- [x] ios-build-check が初回 PR run で成功 (Xcode 26.2 + no download, 9分44秒, commit 0fd25eb)
- [ ] 次回の tag push (\`v0.4.1\` など) で release.yml が成功することを確認
- [ ] JS-only な後続 PR で ios-build-check workflow が起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)