### PR TITLE
Bump buildVersion per release for SideStore update detection

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: release
-description: Cut a new release of the seam iOS app — bump expo.version in packages/app/app.json, create a version-bump commit and a vX.Y.Z tag, then push both to origin/main. Use for any phrasing that means releasing, version bumping, or tagging a new version (English or Japanese: release / version bump / リリース / バージョンアップ / タグを切る).
+description: Cut a new release of the seam iOS app — bump expo.version AND expo.ios.buildNumber in packages/app/app.json, create a version-bump commit and a vX.Y.Z tag, then push both to origin/main. Use for any phrasing that means releasing, version bumping, or tagging a new version (English or Japanese: release / version bump / リリース / バージョンアップ / タグを切る).
 user-invocable: true
 disable-model-invocation: true
 ---
 
 # Release skill
 
-`packages/app/app.json` の `expo.version` を bump し、commit / tag / push して
-`.github/workflows/release.yml` をトリガーするまでを 1 コマンドで行う。
+`packages/app/app.json` の `expo.version` と `expo.ios.buildNumber` を両方 bump し、
+commit / tag / push して `.github/workflows/release.yml` をトリガーするまでを
+1 コマンドで行う。
+
+`buildNumber` を毎回 strictly increase させるのは SideStore / AltStore の update
+検出 (`(version, buildVersion)` tuple 比較) を確実に効かせるための必須手順。
+過去 v0.4.0 で `buildNumber=1` のまま放置していたために OPEN ボタンが stuck する
+事象が発生した。
 
 CI の動作（IPA build、GitHub Release 作成、`docs/source.json` 更新）は責務外。
 tag push が成功したら完了とする。
@@ -50,16 +56,23 @@ tag push が成功したら完了とする。
 6. **Tag 衝突なし**
    - `git tag -l vX.Y.Z` が空、かつ `git ls-remote --tags origin vX.Y.Z` が空
    - 失敗時: 「tag vX.Y.Z は既に存在します。別のバージョンを指定してください」
+7. **`ios.buildNumber` が存在し整数として解釈できる**
+   - `node -p "require('./packages/app/app.json').expo.ios.buildNumber"` が integer 文字列
+   - 失敗時: 「`packages/app/app.json` の `expo.ios.buildNumber` が未設定または不正です。`"buildNumber": "<n>"` を追加してから再実行してください」
 
 ## Procedure
 
-### Step 1: 現バージョン読み取りと引数解析
+### Step 1: 現バージョン / buildNumber 読み取りと引数解析
 
 ```bash
 node -p "require('./packages/app/app.json').expo.version"
+node -p "require('./packages/app/app.json').expo.ios.buildNumber"
 ```
 
-引数の判定:
+新 `buildNumber` は **常に現在値 + 1**（integer として加算、文字列として保存）。
+引数指定不可。
+
+引数 (= version) の判定:
 - `^[0-9]+\.[0-9]+\.[0-9]+$` → 明示バージョン
 - `patch` / `minor` / `major` → 現バージョンから算出
 - 空 → Step 2 へ
@@ -81,17 +94,21 @@ AskUserQuestion で 4 択を提示:
 
 ### Step 4: app.json を編集
 
-`Edit` ツールで `packages/app/app.json` の `"version": "X.Y.Z"` を新バージョンに置き換える。
-他のフィールドには触れない。
+`Edit` ツールで以下 2 箇所を更新する。他のフィールドには触れない。
+
+1. `"version": "A.B.C"` → `"version": "X.Y.Z"`（新バージョン）
+2. `"buildNumber": "<old>"` → `"buildNumber": "<old + 1>"`（現在値 +1）
 
 ### Step 5: Commit
 
 ```bash
 git add packages/app/app.json
-git commit -m "Version bump X.Y.Z"
+git commit -m "Version bump X.Y.Z (build N)"
 ```
 
-過去パターン踏襲（`chore:` プレフィックスなし、3 桁バージョンのみ）。
+`N` は新 `buildNumber`。`Version bump <version> (build <n>)` 形式で固定
+（`chore:` プレフィックスなし）。過去 `Version bump X.Y.Z` 単独だった頃と
+読み取れる semantic は同じ。
 
 ### Step 6: Main を push
 
@@ -118,8 +135,8 @@ lightweight tag（`-a` 不要、過去パターン踏襲）。失敗時: Recover
 完了時に以下を一行ずつ表示:
 
 ```
-Released seam vX.Y.Z (was vA.B.C)
-- commit: <short-hash> "Version bump X.Y.Z"
+Released seam vX.Y.Z build N (was vA.B.C build M)
+- commit: <short-hash> "Version bump X.Y.Z (build N)"
 - tag:    vX.Y.Z (lightweight)
 - pushed: origin/main, origin/refs/tags/vX.Y.Z
 ```
@@ -176,6 +193,10 @@ GitHub Release が作成済みの場合は GitHub UI から削除する必要が
 - バージョンは `MAJOR.MINOR.PATCH` のみ（Apple `CFBundleShortVersionString` ルール、`-beta` 等 pre-release suffix 禁止）
 - tag pattern は `vX.Y.Z`（`v` プレフィックス必須、`.github/workflows/release.yml` の trigger と一致）
 - `app.json` の `expo.version` と tag のバージョン部分（`v` を剥がす）は完全一致必須（mismatch で CI fail-fast）
+- `expo.ios.buildNumber` はリリース毎に **strictly increase**（前回値 +1）。同一値で再リリース禁止
+  — SideStore / AltStore は `(version, buildVersion)` tuple で update 検出するため、
+  同値だと iOS 上書きインストール時の version 比較や stale な `InstalledApp` レコードに
+  対する update 判定で OPEN button stuck になる
 - リリースは `main` ブランチでのみ実行
 - pre-push hook は skip しない（`--no-verify` 禁止）
 - 同じバージョン番号での再リリース禁止（SideStore キャッシュ問題）

--- a/.github/scripts/update-source.mjs
+++ b/.github/scripts/update-source.mjs
@@ -5,11 +5,14 @@ const SOURCE_PATH = path.resolve('docs/source.json');
 const REPO = process.env.REPO;
 const TAG = process.env.TAG;
 const VERSION = process.env.VERSION;
+const BUILD_VERSION = process.env.BUILD_VERSION;
 const IPA_SIZE = Number(process.env.IPA_SIZE);
 const CHANGES = process.env.CHANGES || '';
 
-if (!REPO || !TAG || !VERSION || !Number.isFinite(IPA_SIZE)) {
-  throw new Error(`missing env: REPO=${REPO} TAG=${TAG} VERSION=${VERSION} IPA_SIZE=${IPA_SIZE}`);
+if (!REPO || !TAG || !VERSION || !BUILD_VERSION || !Number.isFinite(IPA_SIZE)) {
+  throw new Error(
+    `missing env: REPO=${REPO} TAG=${TAG} VERSION=${VERSION} BUILD_VERSION=${BUILD_VERSION} IPA_SIZE=${IPA_SIZE}`,
+  );
 }
 
 const downloadURL = `https://github.com/${REPO}/releases/download/${TAG}/Seam-${TAG}.ipa`;
@@ -23,6 +26,7 @@ if (!app) throw new Error('apps[0] not found in source.json');
 
 const newVersion = {
   version: VERSION,
+  buildVersion: BUILD_VERSION,
   date: versionDate,
   localizedDescription: CHANGES.trim() || `Release ${TAG}`,
   downloadURL,
@@ -33,6 +37,7 @@ const newVersion = {
 app.versions = [newVersion, ...(app.versions || []).filter((v) => v.version !== VERSION)];
 
 app.version = newVersion.version;
+app.buildVersion = newVersion.buildVersion;
 app.versionDate = newVersion.date;
 app.versionDescription = newVersion.localizedDescription;
 app.downloadURL = newVersion.downloadURL;
@@ -41,4 +46,6 @@ app.size = newVersion.size;
 source.sourceURL = sourceURL;
 
 fs.writeFileSync(SOURCE_PATH, JSON.stringify(source, null, 2) + '\n');
-console.log(`[update-source] ${VERSION} -> ${downloadURL} (${IPA_SIZE} bytes)`);
+console.log(
+  `[update-source] ${VERSION} (build ${BUILD_VERSION}) -> ${downloadURL} (${IPA_SIZE} bytes)`,
+);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       version: ${{ steps.meta.outputs.version }}
+      build_version: ${{ steps.meta.outputs.build_version }}
       ipa_size: ${{ steps.meta.outputs.ipa_size }}
       ipa_sha256: ${{ steps.meta.outputs.ipa_sha256 }}
       tag: ${{ steps.tag.outputs.tag }}
@@ -161,8 +162,16 @@ jobs:
       - name: Compute metadata
         id: meta
         run: |
+          set -euo pipefail
           IPA="${{ steps.package.outputs.ipa_path }}"
+          INFO_PLIST="$(dirname "$IPA")/Payload/Seam.app/Info.plist"
+          BUILD_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+          if [ -z "$BUILD_VERSION" ]; then
+            echo "::error::failed to read CFBundleVersion from $INFO_PLIST"
+            exit 1
+          fi
           echo "version=${{ steps.tag.outputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
           echo "ipa_size=$(stat -f%z "$IPA")" >> "$GITHUB_OUTPUT"
           echo "ipa_sha256=$(shasum -a 256 "$IPA" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
@@ -218,6 +227,7 @@ jobs:
       - name: Update docs/source.json
         env:
           VERSION: ${{ needs.build-ipa.outputs.version }}
+          BUILD_VERSION: ${{ needs.build-ipa.outputs.build_version }}
           IPA_SIZE: ${{ needs.build-ipa.outputs.ipa_size }}
           TAG: ${{ needs.build-ipa.outputs.tag }}
           CHANGES: ${{ steps.changelog.outputs.changes }}

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -13,7 +13,8 @@
     },
     "ios": {
       "supportsTablet": false,
-      "bundleIdentifier": "com.sugarshin.seam"
+      "bundleIdentifier": "com.sugarshin.seam",
+      "buildNumber": "2"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary

- Add `ios.buildNumber` to `packages/app/app.json` so `expo prebuild` writes a non-default `CFBundleVersion` into `Info.plist`.
- In `.github/workflows/release.yml`, extract the IPA's `CFBundleVersion` via `PlistBuddy` after archiving and surface it as a `build_version` job output.
- In `.github/scripts/update-source.mjs`, read `BUILD_VERSION` from env and write `versions[0].buildVersion` + top-level `app.buildVersion` so SideStore/AltStore have an authoritative `(version, buildVersion)` tuple per release.

## Background

After v0.4.0 was released, SideStore's Browse tab correctly showed `Version 0.4.0`, but the install button stayed on `OPEN` instead of `UPDATE` even though the device still had v0.3.0 installed. Removing and re-adding the source ultimately recovered the update path.

Investigation traced the fragility to `AltStoreCore/Model/InstalledApp.swift`'s update detection:

```swift
func matches(_ appVersion: AppVersion) -> Bool {
    return self.version == appVersion.version
        && self.storeBuildVersion == appVersion.buildVersion
}
```

Because every prior release shipped with `CFBundleVersion = "1"` (Expo's default when `ios.buildNumber` is absent) and our `source.json` omitted `buildVersion`, a single corrupted/cached `InstalledApp` row in SideStore's Core Data is enough to make `matches()` return `true` and suppress the `UPDATE` label.

SideStore has a documented history of update-detection regressions (#576, #593, #611, #666, #802, **PR #900 fixed in 0.6.2**, #975 still open). Bumping `buildVersion` per release gives the comparison a hard differentiator that survives those code paths and SideStore DB cache hiccups.

## Changes

1. `packages/app/app.json` — add `ios.buildNumber: "2"` (previous IPAs were implicitly `"1"`).
2. `.github/workflows/release.yml`
   - Add `build_version` to `build-ipa` job outputs.
   - In `Compute metadata`, run `PlistBuddy -c 'Print :CFBundleVersion'` on `build/Payload/Seam.app/Info.plist` and fail the job if it can't be read.
   - Pass `BUILD_VERSION` into the `Update docs/source.json` step's env.
3. `.github/scripts/update-source.mjs`
   - Require `BUILD_VERSION` env var.
   - Write `versions[0].buildVersion` and top-level `app.buildVersion`.
   - Log line now includes the build version.

## Operational note

The next release MUST bump `ios.buildNumber` along with `expo.version` in `app.json`. Same-version IPAs will fail to upgrade in place because `(version, buildVersion)` becomes equal again. Consider adding a CI guard later that validates `buildNumber` strictly increases (left out of this PR to keep the diff focused).

## Test plan

- [x] `node --check .github/scripts/update-source.mjs`
- [x] Smoke test `update-source.mjs` with mocked env (`REPO`, `TAG`, `VERSION`, `BUILD_VERSION`, `IPA_SIZE`, `CHANGES`); verified `versions[0].buildVersion` and top-level `buildVersion` are written; `docs/source.json` restored after the test.
- [x] `pnpm format:check` (no changes), `pnpm -r typecheck`, `pnpm -r lint`, `pnpm -r test` all green via lefthook on commit.
- [ ] Cut a v0.5.0 tag once merged to validate the full release pipeline end-to-end and confirm SideStore shows `UPDATE` against an installed v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)