### PR TITLE
Update zod to v4 (with z.record() fix)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -45,7 +45,7 @@
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "~4.23.0",
     "react-native-worklets": "0.7.4",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",

--- a/packages/app/src/backup/jsonImport.ts
+++ b/packages/app/src/backup/jsonImport.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { db, schema } from '../db/client';
 
 /** Loose row shape — each table's rows are arbitrary records of scalars. */
-const RowSchema = z.record(z.unknown());
+const RowSchema = z.record(z.string(), z.unknown());
 
 const TablesSchema = z.object({
   items: z.array(RowSchema),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf dist .turbo *.tsbuildinfo"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: 0.7.4
         version: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
@@ -158,8 +158,8 @@ importers:
   packages/shared:
     dependencies:
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -5598,6 +5598,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -11690,3 +11693,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

Zod v4 へのアップグレード。Renovate が起こした #41 が CI typecheck で失敗していたので、`fix/zod-4-record-api` ブランチを `renovate/zod-4.x` から切ってメジャーアップデート対応の修正を1行追加した。

## 修正内容

zod v4 で `z.record(valueSchema)` の1引数オーバーロードが削除され、キースキーマが必須になった。`packages/app/src/backup/jsonImport.ts` の `RowSchema` を `z.record(z.string(), z.unknown())` に修正。

```diff
-const RowSchema = z.record(z.unknown());
+const RowSchema = z.record(z.string(), z.unknown());
```

## 影響範囲調査

- zod import は 17 ファイル / `z.*` API 利用は 223 箇所
- v4 の他の破壊的変更 (`z.coerce` の挙動 / `errorMap` / `deepPartial` / `nativeEnum` / `passthrough` 等) に該当する API は使っていない
- `parse` / `safeParse` 利用は `ExportPayloadSchema.parse` 1 箇所のみ。上位は `err instanceof Error` で `err.message` を表示するだけなので v4 の `ZodError` でもそのまま動作

## Test plan

- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test` — 187 テスト通過 (@seam/app 43 / @seam/domain 144 / @seam/shared)
- [x] `pnpm lint` — 通過
- [x] `pnpm format:check` — 通過
- [ ] CI が緑になることを確認
- [ ] マージ後に #41 をクローズ

## Closes

Supersedes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)