### PR TITLE
Set rootDir on @seam/domain tsconfig for TypeScript 6

### DIFF
--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "..",
     "types": ["vitest/globals"],
     "paths": {
       "@seam/shared": ["../shared/src/index.ts"],


### PR DESCRIPTION
## Summary
- TypeScript 6.0 で `@seam/domain` の `tsc --noEmit` が `TS6059: rootDir` で失敗するのを修正する
- `packages/domain/tsconfig.json` に `"rootDir": ".."` を追加し、`paths` 経由で参照される `../shared/src/*.ts` を rootDir 配下に収める

## Background
[#40](https://github.com/sugarshin/seam/pull/40) (typescript 5.9.3 → 6.0.3) の CI で `@seam/domain` の typecheck が失敗していた:

```
src/compare/compareMeasurements.ts(6,8): error TS6059: File '.../packages/shared/src/index.ts' is not under 'rootDir' '.../packages/domain'.
```

このリポジトリは `@seam/shared` / `@seam/domain` をビルドせず src を直接参照する方針 (CLAUDE.md 参照) のため、`packages/domain/tsconfig.json` の `paths` は `@seam/shared` を `../shared/src/index.ts` にマップしている。

TS 5.9 では暗黙の `rootDir` が include で指定された範囲 (`./src`) から決定され、`paths` 経由で読み込まれる外部 `.ts` は許容されていた。TS 6.0 では `paths` 経由で program に取り込まれた `.ts` についても rootDir チェックが厳格化されたためエラーになる。

このため `domain` の `rootDir` を共通の親ディレクトリ (`..` = `packages/`) に明示することで `domain/src/**` と `shared/src/**` の両方を rootDir 配下に収める形にする。`outDir: ./dist` は据え置き (現状 `tsc --noEmit` のため未使用)。

`packages/shared` は `rootDir: "./src"` 明示済み + include が `src/**/*` に閉じているため影響なし。`packages/app` は expo の base config を継承する `noEmit` 構成で、こちらも影響なし。

## Architecture
```diff
 // packages/domain/tsconfig.json
 "compilerOptions": {
   "outDir": "./dist",
+  "rootDir": "..",
   "types": ["vitest/globals"],
   "paths": {
     "@seam/shared": ["../shared/src/index.ts"],
     "@seam/shared/*": ["../shared/src/*"]
   }
 }
```

## Test plan
ローカル (TS 6.0.3 / pnpm 10.33.2) で確認済み:

- [x] `pnpm typecheck` — 3 packages 全 pass
- [x] `pnpm test` — 198 tests pass (shared 11 / domain 144 / app 43)
- [x] `pnpm format:check` — pass
- [x] `pnpm -r lint` — pass

## Note
このブランチは [#40](https://github.com/sugarshin/seam/pull/40) の `renovate/typescript-6.x` ブランチを base にしている。マージすると Renovate PR (#40) の差分にこの修正が乗る形になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)