### PR TITLE
Version bump 0.4.2 (build 4)

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Seam",
     "slug": "seam",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "seam",
@@ -14,7 +14,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.sugarshin.seam",
-      "buildNumber": "3"
+      "buildNumber": "4"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary

- `packages/app/app.json` の `expo.version` を `0.4.1` → `0.4.2` に bump
- `expo.ios.buildNumber` を `3` → `4` に bump

## Background

`/release patch` 起動時に main 直 push が repository rule（required status checks）で reject されたため、PR 経由に切り替え。

`buildNumber` を毎回 strictly increase させるのは SideStore / AltStore の update 検出 (`(version, buildVersion)` tuple 比較) を効かせるため。

## Release flow (post-merge)

このPRがmergeされた後、main上で以下を実行して `release.yml` をトリガーする:

```sh
git checkout main
git pull --ff-only origin main
git tag v0.4.2
git push origin v0.4.2
```

## Test plan

- [x] pre-push hook (format-check / test / typecheck / lint) が pass
- [ ] CI required checks が pass
- [ ] merge 後 main で `v0.4.2` tag を push して `.github/workflows/release.yml` が成功