### PR TITLE
Rewrite release skill for PR-based flow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: release
-description: Cut a new release of the seam iOS app — bump expo.version AND expo.ios.buildNumber in packages/app/app.json, create a version-bump commit and a vX.Y.Z tag, then push both to origin/main. Use for any phrasing that means releasing, version bumping, or tagging a new version (English or Japanese: release / version bump / リリース / バージョンアップ / タグを切る).
+description: Cut a new release of the seam iOS app via PR-based flow — Phase 1 bumps expo.version + expo.ios.buildNumber in packages/app/app.json on a release/vX.Y.Z branch and opens a PR, Phase 2 (after merge) creates and pushes the vX.Y.Z tag from main. Use for any phrasing that means releasing, version bumping, or tagging a new version (English or Japanese: release / version bump / リリース / バージョンアップ / タグを切る).
 user-invocable: true
 disable-model-invocation: true
 ---
 
 # Release skill
 
-`packages/app/app.json` の `expo.version` と `expo.ios.buildNumber` を両方 bump し、
-commit / tag / push して `.github/workflows/release.yml` をトリガーするまでを
-1 コマンドで行う。
+Seam iOS app のリリースフローを 2 段階で実行する。
+
+- **Phase 1 (PR creation)** — 引数 `patch` / `minor` / `major` / `X.Y.Z` / なし で起動。`packages/app/app.json` の `expo.version` と `expo.ios.buildNumber` を bump した commit を `release/vX.Y.Z` ブランチに作り、PR を作成する。
+- **Phase 2 (Tag push)** — 引数 `tag` で起動。PR が main にマージされたあと、main を pull してから `vX.Y.Z` lightweight tag を作成・push し、`.github/workflows/release.yml` をトリガーする。
+
+main への直接 push は repository ruleset (required status checks) で塞がれているため、PR 経由が必須。
 
 `buildNumber` を毎回 strictly increase させるのは SideStore / AltStore の update
 検出 (`(version, buildVersion)` tuple 比較) を確実に効かせるための必須手順。
@@ -28,13 +31,25 @@ tag push が成功したら完了とする。
 
 ### 引数
 
-| 形式 | 例 | 挙動 |
-|---|---|---|
-| bump キーワード | `patch` / `minor` / `major` | 現バージョンを読み取って自動算出 |
-| 明示バージョン | `0.4.0` | そのまま採用（semver 検証あり） |
-| なし | （引数なしで起動） | 現バージョンを提示 → AskUserQuestion で次バージョンを選択 |
+| 形式 | 例 | フェーズ | 挙動 |
+|---|---|---|---|
+| bump キーワード | `patch` / `minor` / `major` | Phase 1 | 現バージョンを読み取って自動算出 → PR 作成 |
+| 明示バージョン | `0.4.0` | Phase 1 | semver 検証 → PR 作成 |
+| `tag` | `tag` | Phase 2 | merge 済み main を pull → tag 作成 → push |
+| なし | （引数なしで起動） | Phase 1 | AskUserQuestion で次バージョンを選択 → PR 作成 |
 
-## Prerequisites（事前チェック）
+引数判別は厳密に:
+- `tag` 完全一致 → Phase 2
+- `patch` / `minor` / `major` 完全一致 → Phase 1 (bump)
+- `^[0-9]+\.[0-9]+\.[0-9]+$` 一致 → Phase 1 (明示バージョン)
+- 空 → Phase 1 (対話)
+- それ以外 → エラー（「`patch` / `minor` / `major` / `X.Y.Z` / `tag` のいずれかを指定してください」）
+
+---
+
+## Phase 1: PR creation
+
+### Prerequisites（事前チェック）
 
 すべて自動で実行する。1 つでも失敗したら abort してユーザーに原因を伝える。
 
@@ -43,10 +58,10 @@ tag push が成功したら完了とする。
    - 失敗時: 「未コミットの変更があります。先に commit/stash してください」
 2. **現ブランチが main**
    - `git rev-parse --abbrev-ref HEAD` が `main`
-   - 失敗時: 「リリースは main ブランチでのみ可能です」
+   - 失敗時: 「リリースは main ブランチから開始してください（現在: <branch>）」
 3. **Remote と同期**
    - `git fetch origin main` 後、`git rev-list HEAD..origin/main --count` が `0`、かつ `HEAD` が `origin/main` と一致
-   - 失敗時: 「remote main から ahead/behind しています。pull してから再実行してください」
+   - 失敗時: 「remote main から ahead/behind しています。`git pull --ff-only origin main` してから再実行してください」
 4. **バージョン形式**
    - 新バージョンが `^[0-9]+\.[0-9]+\.[0-9]+$` に一致
    - 失敗時: 「Apple ルールにより `MAJOR.MINOR.PATCH` のみ可能です（pre-release suffix 禁止）」
@@ -59,10 +74,14 @@ tag push が成功したら完了とする。
 7. **`ios.buildNumber` が存在し整数として解釈できる**
    - `node -p "require('./packages/app/app.json').expo.ios.buildNumber"` が integer 文字列
    - 失敗時: 「`packages/app/app.json` の `expo.ios.buildNumber` が未設定または不正です。`"buildNumber": "<n>"` を追加してから再実行してください」
+8. **`release/vX.Y.Z` ブランチ衝突なし**
+   - ローカル: `git rev-parse --verify --quiet refs/heads/release/vX.Y.Z` が失敗（= ブランチなし）
+   - remote: `git ls-remote --heads origin release/vX.Y.Z` が空
+   - 失敗時: 「ブランチ `release/vX.Y.Z` が既に存在します。古い PR を close してブランチを削除してから再実行してください」
 
-## Procedure
+### Procedure
 
-### Step 1: 現バージョン / buildNumber 読み取りと引数解析
+#### Step 1: 現バージョン / buildNumber 読み取りと引数解析
 
 ```bash
 node -p "require('./packages/app/app.json').expo.version"
@@ -77,7 +96,7 @@ node -p "require('./packages/app/app.json').expo.ios.buildNumber"
 - `patch` / `minor` / `major` → 現バージョンから算出
 - 空 → Step 2 へ
 
-### Step 2: 引数なしの場合は対話
+#### Step 2: 引数なしの場合は対話
 
 AskUserQuestion で 4 択を提示:
 
@@ -86,20 +105,26 @@ AskUserQuestion で 4 択を提示:
 - `major` (例: `0.3.0` → `1.0.0`)
 - 明示入力（"Other" で `X.Y.Z` を直接入力）
 
-選択後、ユーザーに最終バージョンを再確認しない（Prerequisites 6 項目のチェックで誤入力は捕まえる）。
+選択後、ユーザーに最終バージョンを再確認しない（Prerequisites のチェックで誤入力は捕まえる）。
 
-### Step 3: Prerequisites 6 項目を実行
+#### Step 3: Prerequisites 1〜8 を実行
 
-このタイミングで 1〜6 すべてを順に検証。1 つでも失敗したら abort。
+1 つでも失敗したら abort。
 
-### Step 4: app.json を編集
+#### Step 4: リリースブランチ作成
+
+```bash
+git checkout -b release/vX.Y.Z
+```
+
+#### Step 5: app.json を編集
 
 `Edit` ツールで以下 2 箇所を更新する。他のフィールドには触れない。
 
 1. `"version": "A.B.C"` → `"version": "X.Y.Z"`（新バージョン）
 2. `"buildNumber": "<old>"` → `"buildNumber": "<old + 1>"`（現在値 +1）
 
-### Step 5: Commit
+#### Step 6: Commit
 
 ```bash
 git add packages/app/app.json
@@ -107,74 +132,166 @@ git commit -m "Version bump X.Y.Z (build N)"
 ```
 
 `N` は新 `buildNumber`。`Version bump <version> (build <n>)` 形式で固定
-（`chore:` プレフィックスなし）。過去 `Version bump X.Y.Z` 単独だった頃と
-読み取れる semantic は同じ。
+（`chore:` プレフィックスなし）。
 
-### Step 6: Main を push
+#### Step 7: ブランチを push
 
 ```bash
-git push origin main
+git push -u origin release/vX.Y.Z
 ```
 
 `lefthook.yml` の pre-push hook（format-check / lint / typecheck / test）が走るため
 完了まで待つ。失敗時: Recovery B を提示。
 
-### Step 7: Tag を作成して push
+#### Step 8: PR 作成
 
-main の push 成功を確認してから tag を作成（順序重要）:
+```bash
+gh pr create \
+  --title "Version bump X.Y.Z (build N)" \
+  --base main \
+  --head release/vX.Y.Z \
+  --body "..."
+```
+
+PR body には以下を含める:
+
+- Summary: version / buildNumber を A.B.C / M → X.Y.Z / N に bump した旨
+- Background: SideStore / AltStore update 検出のため `buildNumber` strictly increase が必要
+- Post-merge step: 「merge 後 `/release tag` を実行して `vX.Y.Z` tag を push してください」
+
+### Phase 1 Output
+
+```
+PR created for seam vX.Y.Z build N (was vA.B.C build M)
+- branch: release/vX.Y.Z (commit: <short-hash> "Version bump X.Y.Z (build N)")
+- PR:     <url>
+
+Next: PR を merge した後、`/release tag` で Phase 2 を実行してください。
+```
+
+---
+
+## Phase 2: Tag push
+
+`/release tag` で起動。直前の Phase 1 PR が merge 済みであることが前提。
+
+### Prerequisites
+
+すべて自動で実行する。1 つでも失敗したら abort。
+
+1. **Working directory clean**
+   - `git status --porcelain` が空であること
+2. **現ブランチが main**
+   - 失敗時: 「Phase 2 は main ブランチで実行してください（現在: <branch>）。`git checkout main` してから再実行してください」
+3. **main を最新に同期**
+   - `git fetch origin main` 後、`git pull --ff-only origin main` を実行
+   - fast-forward 不可なら abort: 「local main と remote main が divergeしています。手動で解決してください」
+4. **`app.json` の `expo.version` から target version を取得**
+   - `node -p "require('./packages/app/app.json').expo.version"` で X.Y.Z を取得
+5. **直近の PR merge が version bump commit である**
+   - main の HEAD or 直近 commit に `Version bump X.Y.Z (build N)` が含まれることを確認
+   - `git log -1 --pretty=%s` または `git log -20 --pretty=%s` のいずれかにマッチ
+   - 失敗時: 「`Version bump X.Y.Z` の commit が main の直近に見つかりません。Phase 1 の PR が merge されているか確認してください」
+6. **Tag 未作成**
+   - `git tag -l vX.Y.Z` が空、かつ `git ls-remote --tags origin vX.Y.Z` が空
+   - 失敗時: 「tag vX.Y.Z は既に存在します（`/release tag` を二重実行している可能性）」
+
+### Procedure
+
+#### Step 1: main を最新化
+
+```bash
+git checkout main
+git fetch origin main
+git pull --ff-only origin main
+```
+
+#### Step 2: target version を読み取って Prerequisites を検証
+
+#### Step 3: Tag 作成・push
 
 ```bash
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-lightweight tag（`-a` 不要、過去パターン踏襲）。失敗時: Recovery C を提示。
+lightweight tag（`-a` 不要、過去パターン踏襲）。失敗時: Recovery E を提示。
 
-## Output
+#### Step 4: ローカル release ブランチの後片付け（任意）
 
-完了時に以下を一行ずつ表示:
+```bash
+git branch -d release/vX.Y.Z 2>/dev/null || true
+git fetch --prune origin
+```
+
+remote ブランチは GitHub の auto-delete 設定で merge 時に消えていることが多い。
+残っていれば `git push origin --delete release/vX.Y.Z` で削除。
+
+### Phase 2 Output
 
 ```
-Released seam vX.Y.Z build N (was vA.B.C build M)
-- commit: <short-hash> "Version bump X.Y.Z (build N)"
-- tag:    vX.Y.Z (lightweight)
-- pushed: origin/main, origin/refs/tags/vX.Y.Z
+Released seam vX.Y.Z build N
+- tag:    vX.Y.Z (lightweight) on <merge-commit-short-hash>
+- pushed: origin/refs/tags/vX.Y.Z
 ```
 
 CI URL や release URL は表示しない（責務外）。
 
+---
+
 ## Recovery procedures
 
 スキル実行中に失敗が出たら、その時点での state に該当する手順だけを
-ユーザーに提示する。SKILL.md 全体の参照は不要。
+ユーザーに提示する。
 
-### A: app.json 編集後・commit 前に abort
+### A: Phase 1 — app.json 編集後・commit 前に abort
 
 ```bash
 git checkout packages/app/app.json
+git checkout main
+git branch -D release/vX.Y.Z
 ```
 
-### B: commit 後・main push 前に abort（pre-push hook 失敗を含む）
+### B: Phase 1 — commit 後・branch push 前に abort（pre-push hook 失敗を含む）
 
 ```bash
-git reset --hard HEAD~1
+git checkout main
+git branch -D release/vX.Y.Z
 ```
 
-pre-push hook の失敗は「失敗した check（lint/typecheck/test）を直してから再実行」が正攻法。
-hook を skip しない（system prompt の Git Safety Protocol に従う）。
+pre-push hook の失敗は「失敗した check（lint/typecheck/test/format-check）を直してから
+再実行」が正攻法。hook を skip しない（system prompt の Git Safety Protocol に従う）。
 
-### C: main push 後・tag push 前に問題発覚
+### C: Phase 1 — branch push 後 / PR 作成後に abort
 
-remote main に commit が乗ってしまっているので revert:
+PR 作成済みなら close、リリースブランチを remote / local 両方から削除:
 
 ```bash
-git revert HEAD --no-edit
-git push origin main
+gh pr close <pr-number> --delete-branch  # remote ブランチも一緒に消える
+# 上が使えない場合は個別に:
+# gh pr close <pr-number>
+# git push origin --delete release/vX.Y.Z
+git checkout main
+git branch -D release/vX.Y.Z
 ```
 
-local tag は未作成なので tag 削除は不要。
+### D: Phase 2 — PR merge 後・tag push 前に問題発覚
 
-### D: tag push 後・CI が version mismatch で fail（誤った場合のみ）
+merge 済みの main の commit を revert する。main 直 push は塞がれているので、
+revert PR を作る:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b revert/release-vX.Y.Z
+git revert HEAD --no-edit  # merge commit の場合は -m 1 を付ける
+git push -u origin revert/release-vX.Y.Z
+gh pr create --title "Revert version bump X.Y.Z" --base main --head revert/release-vX.Y.Z --body "..."
+```
+
+このパスは複雑なので、できるだけ Phase 1 で問題を見つけることが重要。
+
+### E: Phase 2 — tag push 後・CI が version mismatch で fail（誤った場合のみ）
 
 remote tag を消して再実行:
 
@@ -188,6 +305,8 @@ git tag -d vX.Y.Z
 
 GitHub Release が作成済みの場合は GitHub UI から削除する必要がある。
 
+---
+
 ## Constraints
 
 - バージョンは `MAJOR.MINOR.PATCH` のみ（Apple `CFBundleShortVersionString` ルール、`-beta` 等 pre-release suffix 禁止）
@@ -197,6 +316,8 @@ GitHub Release が作成済みの場合は GitHub UI から削除する必要が
   — SideStore / AltStore は `(version, buildVersion)` tuple で update 検出するため、
   同値だと iOS 上書きインストール時の version 比較や stale な `InstalledApp` レコードに
   対する update 判定で OPEN button stuck になる
-- リリースは `main` ブランチでのみ実行
+- main への直接 push 禁止（repository ruleset により塞がれている。PR 経由必須）
+- リリースブランチ名は `release/vX.Y.Z` で固定（`/release tag` の検知ロジックがこの規約に依存）
+- Phase 2 は Phase 1 の PR が merge 済みであることが前提
 - pre-push hook は skip しない（`--no-verify` 禁止）
 - 同じバージョン番号での再リリース禁止（SideStore キャッシュ問題）


### PR DESCRIPTION
## Summary

`/release` skill を main 直 push 前提から PR ベース 2 フェーズフローに書き換える。

- **Phase 1** (`/release patch` / `minor` / `major` / `X.Y.Z` / 引数なし): `release/vX.Y.Z` ブランチを切って `app.json` の `expo.version` / `expo.ios.buildNumber` を bump、commit を push し PR を作成するところまで
- **Phase 2** (`/release tag`): merge 済み main を pull → `vX.Y.Z` lightweight tag を作成・push して `release.yml` をトリガー

## Background

main への直接 push が repository ruleset (required status checks) で reject される現状、旧スキル (`git push origin main`) は再現性のあるリリースに使えない。実際 v0.4.2 のリリース時に reject され、PR 経由に切り替えてリリースした (#59)。

その workaround をスキルとして固定化し、毎回手で迂回しなくて済むようにする。

## 主な変更

- 引数仕様を拡張: `tag` 完全一致で Phase 2、それ以外は従来通り Phase 1
- Prerequisites に `release/vX.Y.Z` ブランチ衝突チェックを追加
- Procedure を `git checkout -b release/vX.Y.Z` → bump → commit → push → `gh pr create` の流れに変更
- Phase 2 用に main pull / target version 検出 / tag push の手順を新規追加（merge 済み確認のため `Version bump X.Y.Z` commit が main 直近に存在することも検証）
- Recovery を A/B/C/D/E に再編し、Phase 別・state 別に rollback 手順を整理（PR close / branch 削除 / merge 後の revert PR など）
- Constraints に「main への直接 push 禁止 (repository ruleset)」「リリースブランチ名は `release/vX.Y.Z` 固定」「Phase 2 は Phase 1 PR が merge 済みであること」を追加

## Test plan

- [x] `pnpm format:check` / lint / typecheck / test 全て pass（pre-push hook で確認済み）
- [ ] 次回リリース (v0.4.3 想定) で実フローを試行する