### PR TITLE
Fix item detail/edit screen display issues

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -71,6 +71,7 @@ export default function RootLayout() {
       <Stack
         screenOptions={{
           headerShown: false,
+          headerBackButtonDisplayMode: 'minimal',
           contentStyle: { backgroundColor: palette.bg },
         }}
       >

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -10,8 +10,10 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   CATEGORY_LABEL,
+  FIT_RATING_LABEL,
   ITEM_STATUS_LABEL,
   MEASUREMENT_KEY_LABEL,
   type FailureLog,
@@ -80,6 +82,7 @@ const formatCostPerWear = (n: number | null): string => {
 export default function ItemDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const itemId = typeof id === 'string' ? id : undefined;
+  const insets = useSafeAreaInsets();
 
   const [loaded, setLoaded] = useState<LoadedItem | null>(null);
   const [editing, setEditing] = useState(false);
@@ -376,7 +379,7 @@ export default function ItemDetailScreen() {
   if (editing) {
     return (
       <View style={{ flex: 1, backgroundColor: colors.bg }}>
-        <Stack.Screen options={{ title: '編集', headerShown: true }} />
+        <Stack.Screen options={{ title: '編集', headerShown: true, headerRight: () => null }} />
         <ItemForm
           itemId={itemId}
           tagSuggestions={tagSuggestions}
@@ -462,7 +465,10 @@ export default function ItemDetailScreen() {
           ),
         }}
       />
-      <ScrollView contentContainerStyle={{ paddingBottom: space.xxl }}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: space.xxl + insets.bottom }}
+      >
         {loaded.photos.length > 0 ? (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={photoStrip}>
             {loaded.photos.map((p) => (
@@ -488,12 +494,6 @@ export default function ItemDetailScreen() {
             <Chip label={ITEM_STATUS_LABEL[loaded.item.status]} tone="muted" />
             {loaded.item.isFitAnchor && <Chip label="Fit Anchor" tone="inverse" />}
             {loaded.item.isSellCandidate && <Chip label="売却候補" tone="warning" />}
-            {loaded.item.favoriteScore !== undefined && (
-              <Chip label={`★ ${loaded.item.favoriteScore}`} />
-            )}
-            {loaded.item.conditionRank && (
-              <Chip label={`Cond ${loaded.item.conditionRank}`} tone="muted" />
-            )}
           </View>
         </View>
 
@@ -515,6 +515,11 @@ export default function ItemDetailScreen() {
           <Text style={sectionTitle}>詳細</Text>
           {loaded.item.color && <Kv k="色" v={loaded.item.color} />}
           {loaded.item.sizeLabel && <Kv k="サイズ表記" v={loaded.item.sizeLabel} />}
+          {loaded.item.conditionRank && <Kv k="コンディション" v={loaded.item.conditionRank} />}
+          {loaded.item.fitRating && <Kv k="フィット" v={FIT_RATING_LABEL[loaded.item.fitRating]} />}
+          {loaded.item.favoriteScore !== undefined && (
+            <Kv k="お気に入り度" v={'★'.repeat(loaded.item.favoriteScore)} />
+          )}
           {loaded.item.purchasePrice !== undefined && (
             <Kv k="購入価格" v={`¥${loaded.item.purchasePrice.toLocaleString()}`} />
           )}

--- a/packages/app/src/forms/ItemForm.tsx
+++ b/packages/app/src/forms/ItemForm.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { ScrollView, Switch, Text, View, type ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -169,6 +170,7 @@ export const ItemForm = ({
   onCancel,
   submitting = false,
 }: Props) => {
+  const insets = useSafeAreaInsets();
   const [measurements, setMeasurements] = useState<MeasurementInput[]>(
     defaults?.measurements ?? [],
   );
@@ -313,7 +315,10 @@ export const ItemForm = ({
   return (
     <ScrollView
       style={{ flex: 1, backgroundColor: colors.bg }}
-      contentContainerStyle={{ padding: space.lg, paddingBottom: space.xxl }}
+      contentContainerStyle={{
+        padding: space.lg,
+        paddingBottom: space.xxl + insets.bottom,
+      }}
       keyboardShouldPersistTaps="handled"
     >
       <SectionTitle>基本</SectionTitle>

--- a/packages/shared/src/constants/fitRating.ts
+++ b/packages/shared/src/constants/fitRating.ts
@@ -1,0 +1,9 @@
+import type { FitRating } from '../schemas/item';
+
+export const FIT_RATING_LABEL: Record<FitRating, string> = {
+  too_small: '小さすぎ',
+  just: 'ジャスト',
+  slightly_large: '少し大きい',
+  large: '大きめ',
+  too_large: '大きすぎ',
+};

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from './itemStatus';
 export * from './severityRules';
 export * from './scoreWeights';
 export * from './sourceTypes';
+export * from './fitRating';


### PR DESCRIPTION
## Summary
- iPhone のホームインジケーター下に最後のセクションが隠れていたのを解消（item 詳細・ItemForm 双方の `ScrollView` に `useSafeAreaInsets().bottom` を加算）
- 編集モードでヘッダー右に「編集」リンクが残る・戻るボタンに `(tabs)` と表示されるのを修正（編集モード時は `headerRight: () => null`、ルート Stack に `headerBackButtonDisplayMode: 'minimal'`）
- 詳細画面でしか見られなかった `conditionRank` / `fitRating` / `favoriteScore` を詳細画面でも表示（`@seam/shared` に `FIT_RATING_LABEL` を追加し、サマリ chip と詳細セクションの重複を整理）

## Test plan
- [ ] `pnpm typecheck` が通る
- [ ] `pnpm test` が通る
- [ ] iOS シミュレータで closet → アイテム詳細を開き、最下部の「編集」「削除」ボタンまでスクロールできる
- [ ] アイテム詳細で `コンディション` / `フィット` / `お気に入り度` の値がそれぞれ表示される
- [ ] 編集モードでヘッダー右上に「編集」リンクが出ない
- [ ] 戻るボタンに `(tabs)` のラベルが出ない（chevron のみ）
- [ ] 編集画面で末尾の保存ボタンまでスクロールできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)