### PR TITLE
Add condition rank labels and selection guidelines

### DIFF
--- a/packages/app/app/candidate/[id].tsx
+++ b/packages/app/app/candidate/[id].tsx
@@ -11,6 +11,7 @@ import {
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import {
   CATEGORY_LABEL,
+  CONDITION_RANK_LABEL,
   ITEM_STATUS_LABEL,
   MEASUREMENT_KEY_LABEL,
   SOURCE_TYPE_LABEL,
@@ -627,7 +628,10 @@ export default function CandidateDetailScreen() {
             {c?.sourceType && <Chip label={SOURCE_TYPE_LABEL[c.sourceType]} />}
             {loaded.item.isFitAnchor && <Chip label="Fit Anchor" tone="inverse" />}
             {loaded.item.conditionRank && (
-              <Chip label={`Cond ${loaded.item.conditionRank}`} tone="muted" />
+              <Chip
+                label={`${loaded.item.conditionRank} · ${CONDITION_RANK_LABEL[loaded.item.conditionRank]}`}
+                tone="muted"
+              />
             )}
           </View>
         </View>

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -13,6 +13,7 @@ import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   CATEGORY_LABEL,
+  CONDITION_RANK_LABEL,
   FIT_RATING_LABEL,
   ITEM_STATUS_LABEL,
   MEASUREMENT_KEY_LABEL,
@@ -515,7 +516,12 @@ export default function ItemDetailScreen() {
           <Text style={sectionTitle}>詳細</Text>
           {loaded.item.color && <Kv k="色" v={loaded.item.color} />}
           {loaded.item.sizeLabel && <Kv k="サイズ表記" v={loaded.item.sizeLabel} />}
-          {loaded.item.conditionRank && <Kv k="コンディション" v={loaded.item.conditionRank} />}
+          {loaded.item.conditionRank && (
+            <Kv
+              k="コンディション"
+              v={`${loaded.item.conditionRank} — ${CONDITION_RANK_LABEL[loaded.item.conditionRank]}`}
+            />
+          )}
           {loaded.item.fitRating && <Kv k="フィット" v={FIT_RATING_LABEL[loaded.item.fitRating]} />}
           {loaded.item.favoriteScore !== undefined && (
             <Kv k="お気に入り度" v={'★'.repeat(loaded.item.favoriteScore)} />

--- a/packages/app/src/components/Picker.tsx
+++ b/packages/app/src/components/Picker.tsx
@@ -14,6 +14,7 @@ import { colors, font, radii, space } from '../theme';
 export type PickerOption<T extends string> = {
   value: T;
   label: string;
+  description?: string;
 };
 
 type Props<T extends string> = {
@@ -57,9 +58,14 @@ export function Picker<T extends string>({
           pressed && { opacity: 0.6 },
         ]}
       >
-        <Text style={[rowLabel, selected && { fontWeight: font.weight.semibold }]}>
-          {item.label}
-        </Text>
+        <View style={rowTextWrap}>
+          <Text style={[rowLabel, selected && { fontWeight: font.weight.semibold }]}>
+            {item.label}
+          </Text>
+          {item.description !== undefined && item.description !== '' && (
+            <Text style={rowDescription}>{item.description}</Text>
+          )}
+        </View>
         {selected && <Text style={checkMark}>✓</Text>}
       </Pressable>
     );
@@ -190,10 +196,20 @@ const rowStyle: ViewStyle = {
   paddingVertical: space.md,
 };
 
-const rowLabel = {
+const rowTextWrap: ViewStyle = {
   flex: 1,
+};
+
+const rowLabel = {
   fontSize: font.size.md,
   color: colors.text,
+} as const;
+
+const rowDescription = {
+  marginTop: 2,
+  fontSize: font.size.xs,
+  color: colors.textMuted,
+  lineHeight: font.size.xs * 1.4,
 } as const;
 
 const checkMark = {

--- a/packages/app/src/forms/ItemForm.tsx
+++ b/packages/app/src/forms/ItemForm.tsx
@@ -7,6 +7,8 @@ import { z } from 'zod';
 import {
   CATEGORY_LABEL,
   CONDITION_RANKS,
+  CONDITION_RANK_DESCRIPTION,
+  CONDITION_RANK_LABEL,
   GARMENT_CATEGORIES,
   ITEM_STATUSES,
   ITEM_STATUS_LABEL,
@@ -133,7 +135,8 @@ const CATEGORY_OPTIONS: readonly PickerOption<GarmentCategory>[] = GARMENT_CATEG
 
 const CONDITION_OPTIONS: readonly PickerOption<ConditionRank>[] = CONDITION_RANKS.map((r) => ({
   value: r,
-  label: r,
+  label: `${r} — ${CONDITION_RANK_LABEL[r]}`,
+  description: CONDITION_RANK_DESCRIPTION[r],
 }));
 
 const FIT_RATING_OPTIONS: readonly PickerOption<NonNullable<ItemFormValues['fitRating']>>[] = [

--- a/packages/shared/src/constants/scoreWeights.ts
+++ b/packages/shared/src/constants/scoreWeights.ts
@@ -47,3 +47,27 @@ export const CONDITION_RANK_SCORE: Record<'S' | 'A' | 'B' | 'C' | 'D', number> =
 
 export type ConditionRank = keyof typeof CONDITION_RANK_SCORE;
 export const CONDITION_RANKS: readonly ConditionRank[] = ['S', 'A', 'B', 'C', 'D'];
+
+/**
+ * 古着 / 中古品業界 (ヤフオク・メルカリ・Grailed 等) の標準的な
+ * コンディション区分を踏まえた表示ラベル。
+ */
+export const CONDITION_RANK_LABEL: Record<ConditionRank, string> = {
+  S: '新品・未使用',
+  A: '美品',
+  B: '良好',
+  C: 'やや使用感あり',
+  D: '難あり',
+};
+
+/**
+ * コンディションを判定するときの目安。Picker の補助テキストとして表示する。
+ * 業界標準の中古コンディション基準を簡略化した内容。
+ */
+export const CONDITION_RANK_DESCRIPTION: Record<ConditionRank, string> = {
+  S: 'タグ付き / デッドストック。一度も着用していない',
+  A: '着用数回程度。目立つ汚れ・ダメージなし、新品に近い状態',
+  B: '通常の使用感あり。目立つダメージなし、軽微な使用痕のみ',
+  C: '使用感がはっきり。小さなシミ・色あせ・ほつれなど軽微なダメージあり',
+  D: '目立つダメージあり (破れ・大きなシミ・色あせ・リペア跡)。ジャンク扱い',
+};

--- a/packages/shared/src/schemas/item.ts
+++ b/packages/shared/src/schemas/item.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { GARMENT_CATEGORIES } from '../constants/categories';
 import { ITEM_STATUSES } from '../constants/itemStatus';
-import { CONDITION_RANKS } from '../constants/scoreWeights';
+import { CONDITION_RANKS, type ConditionRank } from '../constants/scoreWeights';
 
 export const FitRatingSchema = z.enum([
   'too_small',
@@ -36,7 +36,7 @@ export const GarmentItemSchema = z.object({
   purchaseDate: z.string().optional(),
   purchaseSource: z.string().optional(),
   productUrl: z.string().url().optional().or(z.literal('')),
-  conditionRank: z.enum(CONDITION_RANKS as readonly [string, ...string[]]).optional(),
+  conditionRank: z.enum(CONDITION_RANKS as readonly [ConditionRank, ...ConditionRank[]]).optional(),
   conditionNotes: z.string().optional(),
   fitRating: FitRatingSchema.optional(),
   favoriteScore: FavoriteScoreSchema.optional(),


### PR DESCRIPTION
## Summary

- S/A/B/C/D のコンディション選択時に「何を基準に選ぶか」の指標がなかったので、ヤフオク・メルカリ・Grailed 等の中古品業界の標準的な区分をベースにラベルと判定の目安を追加
- `Picker` に `description` フィールドを追加し、コンディション選択モーダル・アイテム詳細・候補 Chip でラベルが見えるように

## Background

S だけ「新品」と分かっていて、A〜D の判定が感覚頼みになっていた。再評価のたびにブレるので、業界標準を参考に固定の指標を入れて記録/比較が安定するようにする。

## Condition guideline (industry standard)

| Rank | Label | 判定の目安 |
|---|---|---|
| **S** | 新品・未使用 | タグ付き / デッドストック。一度も着用していない |
| **A** | 美品 | 着用数回程度。目立つ汚れ・ダメージなし、新品に近い状態 |
| **B** | 良好 | 通常の使用感あり。目立つダメージなし、軽微な使用痕のみ |
| **C** | やや使用感あり | 使用感がはっきり。小さなシミ・色あせ・ほつれなど軽微なダメージあり |
| **D** | 難あり | 目立つダメージあり (破れ・大きなシミ・色あせ・リペア跡)。ジャンク扱い |

## Changes

- `packages/shared/src/constants/scoreWeights.ts`
  - `CONDITION_RANK_LABEL` (短い表示名) と `CONDITION_RANK_DESCRIPTION` (判定の目安) を追加
- `packages/shared/src/schemas/item.ts`
  - `GarmentItemSchema.conditionRank` を `string` ではなく `ConditionRank` で型付け (使用側で `Record<ConditionRank, ...>` にインデックスアクセスするため)
- `packages/app/src/components/Picker.tsx`
  - `PickerOption` に `description?: string` を追加。モーダル行の label 下に小さく説明を表示
- `packages/app/src/forms/ItemForm.tsx`
  - コンディション Picker のオプションを ``${rank} — ${LABEL}`` + `description` 形式に
- `packages/app/app/item/[id].tsx`
  - 詳細表示を `S — 新品・未使用` 形式に
- `packages/app/app/candidate/[id].tsx`
  - Chip を `S · 新品・未使用` 形式に

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r test`
- [x] `pnpm -r lint`
- [x] `pnpm format:check`
- [ ] iOS Simulator で ItemForm のコンディション Picker を開き、S〜D それぞれにラベル/説明が表示されること
- [ ] アイテム詳細画面でコンディションが `S — 新品・未使用` 形式で表示されること
- [ ] 候補詳細画面の Chip が `S · 新品・未使用` 形式で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)