### PR TITLE
Add product URL to wishlist items and make memo URLs clickable

### DIFF
--- a/packages/app/app/candidate/[id].tsx
+++ b/packages/app/app/candidate/[id].tsx
@@ -9,6 +9,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   CATEGORY_LABEL,
   CONDITION_RANK_LABEL,
@@ -34,6 +35,7 @@ import type { ExtractedMeasurement } from '@seam/domain';
 import { BrandChecklist } from '../../src/components/BrandChecklist';
 import { Button } from '../../src/components/Button';
 import { Chip } from '../../src/components/Chip';
+import { LinkText } from '../../src/components/LinkText';
 import { DecisionReasonModal } from '../../src/components/DecisionReasonModal';
 import { MeasurementExtractionReviewModal } from '../../src/components/MeasurementExtractionReviewModal';
 import {
@@ -151,6 +153,7 @@ const formatDate = (iso?: string): string => {
 export default function CandidateDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const itemId = typeof id === 'string' ? id : undefined;
+  const insets = useSafeAreaInsets();
 
   const [loaded, setLoaded] = useState<LoadedCandidate | null>(null);
   const [editing, setEditing] = useState(false);
@@ -514,7 +517,7 @@ export default function CandidateDetailScreen() {
     const c = loaded.candidate;
     return (
       <View style={{ flex: 1, backgroundColor: colors.bg }}>
-        <Stack.Screen options={{ title: '編集', headerShown: true }} />
+        <Stack.Screen options={{ title: '編集', headerShown: true, headerRight: () => null }} />
         <ItemForm
           itemId={itemId}
           tagSuggestions={tagSuggestions}
@@ -601,7 +604,10 @@ export default function CandidateDetailScreen() {
           ),
         }}
       />
-      <ScrollView contentContainerStyle={{ paddingBottom: space.xxl }}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: space.xxl + insets.bottom }}
+      >
         {loaded.photos.length > 0 ? (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={photoStrip}>
             {loaded.photos.map((p) => (
@@ -888,11 +894,11 @@ export default function CandidateDetailScreen() {
 const Kv = ({ k, v, emphasize }: { k: string; v: string; emphasize?: boolean }) => (
   <View style={kvRow}>
     <Text style={kvKey}>{k}</Text>
-    <Text
+    <LinkText
       style={[kvVal, emphasize ? { color: colors.warning, fontWeight: font.weight.bold } : null]}
     >
       {v}
-    </Text>
+    </LinkText>
   </View>
 );
 

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -29,6 +29,7 @@ import {
 import { calculateCostPerWear, calculateNetCostPerWear } from '@seam/domain';
 import { Button } from '../../src/components/Button';
 import { Chip } from '../../src/components/Chip';
+import { LinkText } from '../../src/components/LinkText';
 import { FailureLogEntry } from '../../src/components/FailureLogEntry';
 import { FailureLogModal, type FailureLogDraft } from '../../src/components/FailureLogModal';
 import { SaleInfoModal, type SaleInfoDraft } from '../../src/components/SaleInfoModal';
@@ -697,7 +698,7 @@ export default function ItemDetailScreen() {
 const Kv = ({ k, v }: { k: string; v: string }) => (
   <View style={kvRow}>
     <Text style={kvKey}>{k}</Text>
-    <Text style={kvVal}>{v}</Text>
+    <LinkText style={kvVal}>{v}</LinkText>
   </View>
 );
 

--- a/packages/app/src/components/LinkText.tsx
+++ b/packages/app/src/components/LinkText.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { Linking, type StyleProp, Text, type TextStyle } from 'react-native';
+import { colors, font } from '../theme';
+
+type Props = {
+  children: string;
+  style?: StyleProp<TextStyle>;
+  linkStyle?: StyleProp<TextStyle>;
+  numberOfLines?: number;
+};
+
+const URL_REGEX = /https?:\/\/[^\s]+/g;
+const TRAILING_PUNCT_REGEX = /[.,;:!?)\]}>'"]+$/;
+
+type Segment = { type: 'text' | 'link'; value: string };
+
+const buildSegments = (input: string): readonly Segment[] => {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  URL_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null = URL_REGEX.exec(input);
+  while (match !== null) {
+    const start = match.index;
+    let url = match[0];
+    let trailing = '';
+    const tail = url.match(TRAILING_PUNCT_REGEX);
+    if (tail) {
+      trailing = tail[0];
+      url = url.slice(0, url.length - trailing.length);
+    }
+    if (start > lastIndex) {
+      segments.push({ type: 'text', value: input.slice(lastIndex, start) });
+    }
+    segments.push({ type: 'link', value: url });
+    if (trailing) {
+      segments.push({ type: 'text', value: trailing });
+    }
+    lastIndex = start + match[0].length;
+    match = URL_REGEX.exec(input);
+  }
+  if (lastIndex < input.length) {
+    segments.push({ type: 'text', value: input.slice(lastIndex) });
+  }
+  return segments;
+};
+
+export const LinkText = ({ children, style, linkStyle, numberOfLines }: Props) => {
+  const segments = useMemo(() => buildSegments(children), [children]);
+
+  return (
+    <Text style={style} numberOfLines={numberOfLines}>
+      {segments.map((s, i) =>
+        s.type === 'link' ? (
+          <Text
+            key={`${i}-link`}
+            style={[defaultLinkStyle, linkStyle]}
+            onPress={() => {
+              void Linking.openURL(s.value);
+            }}
+            accessibilityRole="link"
+          >
+            {s.value}
+          </Text>
+        ) : (
+          <Text key={`${i}-text`}>{s.value}</Text>
+        ),
+      )}
+    </Text>
+  );
+};
+
+const defaultLinkStyle: TextStyle = {
+  color: colors.accent,
+  textDecorationLine: 'underline',
+  fontWeight: font.weight.medium,
+};

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -5,6 +5,7 @@ export { Picker } from './Picker';
 export type { PickerOption } from './Picker';
 export { Chip } from './Chip';
 export type { ChipTone } from './Chip';
+export { LinkText } from './LinkText';
 export { SegmentedControl } from './SegmentedControl';
 export type { SegmentOption } from './SegmentedControl';
 export { EmptyState } from './EmptyState';

--- a/packages/app/src/forms/ItemForm.tsx
+++ b/packages/app/src/forms/ItemForm.tsx
@@ -518,6 +518,23 @@ export const ItemForm = ({
             )}
           />
 
+          <Controller
+            control={control}
+            name="productUrl"
+            render={({ field }) => (
+              <TextField
+                label="商品 URL"
+                value={field.value ?? ''}
+                onChangeText={field.onChange}
+                onBlur={field.onBlur}
+                error={errors.productUrl?.message}
+                keyboardType="url"
+                autoCapitalize="none"
+                placeholder="https://jp.mercari.com/item/..."
+              />
+            )}
+          />
+
           <View style={twoColumn}>
             <View style={{ flex: 1 }}>
               <Controller


### PR DESCRIPTION
## Summary

- Wishlist (候補) フォームの「販売情報」セクションに任意の商品 URL 入力欄を追加（メルカリ・ヤフオク等の出品 URL を保存できる）
- 詳細画面で URL / メモに貼った `http(s)://...` を自動検出してタップで Safari に飛べるよう `LinkText` コンポーネントを導入
- Closet (#63) と同じ要領で、候補詳細でも編集モード時にヘッダー右の「編集」リンクを消し、最下部のボタン群がホームインジケーターに被らないよう `useSafeAreaInsets().bottom` を加算

## Background

メルカリ・ヤフオクで見かけた候補の URL を残しておきたかったが、`items.product_url` は所有アイテム (`owned`) の購入情報セクションでしか入力欄が出ていなかったので候補ステータスでも露出させた。DB スキーマは無変更（既存カラムを流用）。

URL クリッカブル化は、メモ/出品説明/ダメージメモなど Kv で表示している任意のテキストフィールドに貼ったリンクから直接遷移できるようにするのが目的。`Kv` の表示部を `LinkText` に差し替えるだけで他の Kv 行（例: 出品説明文中の URL）にも波及する。

## Changes

- `packages/app/src/components/LinkText.tsx` (新規)
  - 文字列内の `http(s)://...` を検出して該当セグメントを `Linking.openURL` で開く `<Text>` に変換
  - 末尾の句読点 `.,;:!?)\]}>'\"` はリンクから除外
- `packages/app/src/components/index.ts`
  - `LinkText` を re-export
- `packages/app/src/forms/ItemForm.tsx`
  - 候補ステータス（`wishlist`/`watching`/`bidding`/`negotiating`）の販売情報セクションに「商品 URL」フィールドを追加。プレースホルダーにメルカリ URL の例
  - バリデーションは既存の `productUrl` ルールをそのまま利用（`http(s)://` 始まり / 空文字許容）
- `packages/app/app/candidate/[id].tsx`
  - 編集モード時の `Stack.Screen` に `headerRight: () => null` を追加
  - `ScrollView` に `style={{ flex: 1 }}` と `paddingBottom: space.xxl + insets.bottom`
  - ローカル `Kv` の値表示を `LinkText` ベースに変更
- `packages/app/app/item/[id].tsx`
  - ローカル `Kv` の値表示を `LinkText` ベースに変更（メモに貼った URL に対応）

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r test`
- [x] `pnpm -r lint`
- [x] `pnpm format:check`
- [x] lefthook pre-commit / pre-push 全 pass
- [ ] iOS Simulator で Wishlist → 新規追加 → 「商品 URL」欄が販売情報セクションに表示される
- [ ] 候補詳細の販売情報に URL が表示され、タップで Safari に遷移する
- [ ] メモ欄に `https://example.com` を入れて保存、詳細画面で下線付きで表示されタップ遷移する
- [ ] 候補詳細を編集モードに入ったとき、ヘッダー右に「編集」リンクが残らない
- [ ] 候補詳細の最下部ボタン群がホームインジケーターに被らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)