### PR TITLE
Add tap-to-zoom image viewer for detail screens

### DIFF
--- a/packages/app/app/candidate/[id].tsx
+++ b/packages/app/app/candidate/[id].tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Pressable,
   ScrollView,
   Text,
   View,
@@ -35,6 +36,7 @@ import type { ExtractedMeasurement } from '@seam/domain';
 import { BrandChecklist } from '../../src/components/BrandChecklist';
 import { Button } from '../../src/components/Button';
 import { Chip } from '../../src/components/Chip';
+import { ImageViewerModal } from '../../src/components/ImageViewerModal';
 import { LinkText } from '../../src/components/LinkText';
 import { DecisionReasonModal } from '../../src/components/DecisionReasonModal';
 import { MeasurementExtractionReviewModal } from '../../src/components/MeasurementExtractionReviewModal';
@@ -166,6 +168,7 @@ export default function CandidateDetailScreen() {
   const [extractionSubmitting, setExtractionSubmitting] = useState(false);
   const [reminderModalVisible, setReminderModalVisible] = useState(false);
   const [reminderSubmitting, setReminderSubmitting] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
 
   const refresh = useCallback(async () => {
     if (!itemId) return;
@@ -610,12 +613,15 @@ export default function CandidateDetailScreen() {
       >
         {loaded.photos.length > 0 ? (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={photoStrip}>
-            {loaded.photos.map((p) => (
-              <Image
+            {loaded.photos.map((p, i) => (
+              <Pressable
                 key={p.id}
-                source={{ uri: absolutePathFor(p.relativePath) }}
-                style={photoLarge}
-              />
+                accessibilityRole="imagebutton"
+                accessibilityLabel="画像を拡大"
+                onPress={() => setViewerIndex(i)}
+              >
+                <Image source={{ uri: absolutePathFor(p.relativePath) }} style={photoLarge} />
+              </Pressable>
             ))}
           </ScrollView>
         ) : (
@@ -886,6 +892,13 @@ export default function CandidateDetailScreen() {
         submitting={reminderSubmitting}
         onCancel={() => setReminderModalVisible(false)}
         onSubmit={onReminderSubmit}
+      />
+
+      <ImageViewerModal
+        visible={viewerIndex !== null}
+        uris={loaded.photos.map((p) => absolutePathFor(p.relativePath))}
+        initialIndex={viewerIndex ?? 0}
+        onRequestClose={() => setViewerIndex(null)}
       />
     </View>
   );

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Pressable,
   ScrollView,
   Switch,
   Text,
@@ -29,6 +30,7 @@ import {
 import { calculateCostPerWear, calculateNetCostPerWear } from '@seam/domain';
 import { Button } from '../../src/components/Button';
 import { Chip } from '../../src/components/Chip';
+import { ImageViewerModal } from '../../src/components/ImageViewerModal';
 import { LinkText } from '../../src/components/LinkText';
 import { FailureLogEntry } from '../../src/components/FailureLogEntry';
 import { FailureLogModal, type FailureLogDraft } from '../../src/components/FailureLogModal';
@@ -98,6 +100,7 @@ export default function ItemDetailScreen() {
   const [saleModalOpen, setSaleModalOpen] = useState(false);
   const [saleSubmitting, setSaleSubmitting] = useState(false);
   const [sellCandidateBusy, setSellCandidateBusy] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
 
   const refresh = useCallback(async () => {
     if (!itemId) return;
@@ -473,12 +476,15 @@ export default function ItemDetailScreen() {
       >
         {loaded.photos.length > 0 ? (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={photoStrip}>
-            {loaded.photos.map((p) => (
-              <Image
+            {loaded.photos.map((p, i) => (
+              <Pressable
                 key={p.id}
-                source={{ uri: absolutePathFor(p.relativePath) }}
-                style={photoLarge}
-              />
+                accessibilityRole="imagebutton"
+                accessibilityLabel="画像を拡大"
+                onPress={() => setViewerIndex(i)}
+              >
+                <Image source={{ uri: absolutePathFor(p.relativePath) }} style={photoLarge} />
+              </Pressable>
             ))}
           </ScrollView>
         ) : (
@@ -690,6 +696,13 @@ export default function ItemDetailScreen() {
         initial={loaded.saleInfo}
         onCancel={() => setSaleModalOpen(false)}
         onSubmit={(draft) => void submitSale(draft)}
+      />
+
+      <ImageViewerModal
+        visible={viewerIndex !== null}
+        uris={loaded.photos.map((p) => absolutePathFor(p.relativePath))}
+        initialIndex={viewerIndex ?? 0}
+        onRequestClose={() => setViewerIndex(null)}
       />
     </View>
   );

--- a/packages/app/src/components/ImageViewerModal.tsx
+++ b/packages/app/src/components/ImageViewerModal.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useState } from 'react';
+import {
+  Dimensions,
+  FlatList,
+  Image,
+  Modal,
+  Pressable,
+  StatusBar,
+  Text,
+  View,
+  type ListRenderItemInfo,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  type ViewStyle,
+} from 'react-native';
+import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { font, space } from '../theme';
+
+const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 4;
+const DOUBLE_TAP_SCALE = 2.5;
+
+type Props = {
+  visible: boolean;
+  uris: readonly string[];
+  initialIndex?: number;
+  onRequestClose: () => void;
+};
+
+export const ImageViewerModal = ({ visible, uris, initialIndex = 0, onRequestClose }: Props) => {
+  const insets = useSafeAreaInsets();
+  const [scrollEnabled, setScrollEnabled] = useState(true);
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+
+  const onScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>): void => {
+      const i = Math.round(e.nativeEvent.contentOffset.x / SCREEN_W);
+      if (i !== activeIndex) setActiveIndex(i);
+    },
+    [activeIndex],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<string>) => (
+      <ZoomableImage uri={item} onZoomChange={setScrollEnabled} />
+    ),
+    [],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onRequestClose}
+      statusBarTranslucent
+    >
+      <StatusBar hidden />
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <View style={backdrop}>
+          {visible && (
+            <FlatList
+              key={`${initialIndex}-${uris.length}`}
+              data={uris as string[]}
+              keyExtractor={(uri, i) => `${i}-${uri}`}
+              horizontal
+              pagingEnabled
+              scrollEnabled={scrollEnabled}
+              showsHorizontalScrollIndicator={false}
+              initialScrollIndex={initialIndex}
+              getItemLayout={(_, index) => ({
+                length: SCREEN_W,
+                offset: SCREEN_W * index,
+                index,
+              })}
+              onScroll={onScroll}
+              scrollEventThrottle={16}
+              renderItem={renderItem}
+            />
+          )}
+          {uris.length > 1 && (
+            <View style={[counter, { top: insets.top + space.sm }]} pointerEvents="none">
+              <Text style={counterText}>
+                {activeIndex + 1} / {uris.length}
+              </Text>
+            </View>
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="閉じる"
+            onPress={onRequestClose}
+            hitSlop={12}
+            style={[closeBtn, { top: insets.top + space.sm }]}
+          >
+            <Text style={closeMark}>×</Text>
+          </Pressable>
+        </View>
+      </GestureHandlerRootView>
+    </Modal>
+  );
+};
+
+type ZoomableImageProps = {
+  uri: string;
+  onZoomChange: (canScroll: boolean) => void;
+};
+
+const ZoomableImage = ({ uri, onZoomChange }: ZoomableImageProps) => {
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedTranslateX = useSharedValue(0);
+  const savedTranslateY = useSharedValue(0);
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((e) => {
+      const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, savedScale.value * e.scale));
+      scale.value = next;
+    })
+    .onEnd(() => {
+      if (scale.value < 1.01) {
+        scale.value = withTiming(1);
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+        savedScale.value = 1;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
+        runOnJS(onZoomChange)(true);
+      } else {
+        savedScale.value = scale.value;
+        runOnJS(onZoomChange)(false);
+      }
+    });
+
+  const pan = Gesture.Pan()
+    .averageTouches(true)
+    .minPointers(1)
+    .maxPointers(2)
+    .onUpdate((e) => {
+      if (savedScale.value <= 1.01) return;
+      const maxX = (SCREEN_W * (savedScale.value - 1)) / 2;
+      const maxY = (SCREEN_H * (savedScale.value - 1)) / 2;
+      const nextX = savedTranslateX.value + e.translationX;
+      const nextY = savedTranslateY.value + e.translationY;
+      translateX.value = Math.min(maxX, Math.max(-maxX, nextX));
+      translateY.value = Math.min(maxY, Math.max(-maxY, nextY));
+    })
+    .onEnd(() => {
+      savedTranslateX.value = translateX.value;
+      savedTranslateY.value = translateY.value;
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .maxDuration(250)
+    .onEnd(() => {
+      if (savedScale.value > 1.01) {
+        scale.value = withTiming(1);
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+        savedScale.value = 1;
+        savedTranslateX.value = 0;
+        savedTranslateY.value = 0;
+        runOnJS(onZoomChange)(true);
+      } else {
+        scale.value = withTiming(DOUBLE_TAP_SCALE);
+        savedScale.value = DOUBLE_TAP_SCALE;
+        runOnJS(onZoomChange)(false);
+      }
+    });
+
+  const composed = Gesture.Simultaneous(Gesture.Race(doubleTap, pinch), pan);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  return (
+    <View style={page}>
+      <GestureDetector gesture={composed}>
+        <Animated.View style={[pageInner, animatedStyle]}>
+          <Image source={{ uri }} resizeMode="contain" style={image} />
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+};
+
+const backdrop: ViewStyle = {
+  flex: 1,
+  backgroundColor: '#000000',
+};
+
+const page: ViewStyle = {
+  width: SCREEN_W,
+  height: SCREEN_H,
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+};
+
+const pageInner: ViewStyle = {
+  width: SCREEN_W,
+  height: SCREEN_H,
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const image = {
+  width: SCREEN_W,
+  height: SCREEN_H,
+} as const;
+
+const closeBtn: ViewStyle = {
+  position: 'absolute',
+  right: space.lg,
+  width: 40,
+  height: 40,
+  borderRadius: 20,
+  backgroundColor: 'rgba(0,0,0,0.55)',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const closeMark = {
+  color: '#FFFFFF',
+  fontSize: 26,
+  lineHeight: 28,
+  fontWeight: font.weight.semibold,
+} as const;
+
+const counter: ViewStyle = {
+  position: 'absolute',
+  alignSelf: 'center',
+  paddingHorizontal: space.md,
+  paddingVertical: 4,
+  borderRadius: 12,
+  backgroundColor: 'rgba(0,0,0,0.55)',
+};
+
+const counterText = {
+  color: '#FFFFFF',
+  fontSize: font.size.sm,
+  fontWeight: font.weight.semibold,
+} as const;

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -12,6 +12,7 @@ export { EmptyState } from './EmptyState';
 export { ItemCard } from './ItemCard';
 export { MeasurementInputGroup } from './MeasurementInputGroup';
 export { PhotoPicker } from './PhotoPicker';
+export { ImageViewerModal } from './ImageViewerModal';
 export { TagInput } from './TagInput';
 export { DiffRow } from './DiffRow';
 export { SeverityBadge } from './SeverityBadge';


### PR DESCRIPTION
## Summary
- Closet/Wishlist 詳細画面の写真サムネイルをタップしたら、フルスクリーンの画像ビューワで拡大表示できるようにした
- ピンチ拡大 (1.0x〜4.0x)、ダブルタップで 1x ↔ 2.5x トグル、ズーム中はドラッグでパン、横スワイプで複数画像切替に対応
- 既存の `react-native-gesture-handler` v2 + `react-native-reanimated` v4 で実装。新規依存追加なし

## Implementation
- 新規 `packages/app/src/components/ImageViewerModal.tsx` を追加
  - `Modal` 内に `FlatList` (horizontal, pagingEnabled) で複数画像を表示
  - 各ページは `GestureDetector` で pinch + pan + double-tap を合成 (`Gesture.Simultaneous(Gesture.Race(doubleTap, pinch), pan)`)
  - ズーム中は親 FlatList の `scrollEnabled` を切ってページ送りとの衝突を回避
  - パンは `SCREEN * (scale - 1) / 2` で境界クランプ
  - iOS で Modal が `GestureHandlerRootView` の外に出る問題対策として内側にも `GestureHandlerRootView` を再配置
- `packages/app/app/item/[id].tsx` / `candidate/[id].tsx` のサムネイル `Image` を `Pressable` でラップして `viewerIndex` state でモーダルを開閉

## Test plan
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` 通過
- [ ] 実機で Closet 詳細を開き、写真をタップして拡大ビューワが開くこと
- [ ] ピンチで拡大・縮小できること、ダブルタップで 1x ↔ 2.5x トグルできること
- [ ] 拡大状態でドラッグするとパンできること、画面外に飛んでいかないこと
- [ ] 写真が複数あるとき、横スワイプで切り替えられること、`{n / total}` カウンタが追従すること
- [ ] × ボタンとハードウェアバックで閉じられること
- [ ] Wishlist 詳細でも同じ挙動になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)