### PR TITLE
feat(e2e): CUJ-based Maestro suite + comprehensive testID coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,7 @@ eas.json.local
 # Drizzle
 drizzle/.snapshot/
 
-# Maestro
-.maestro/
+# Maestro — flows themselves are tracked; only debug output is ignored.
 maestro-debug-output/
 
 # Claude Code (local-only files)

--- a/.maestro/00_smoke.yaml
+++ b/.maestro/00_smoke.yaml
@@ -1,0 +1,32 @@
+appId: com.sugarshin.seam
+name: smoke
+tags:
+  - smoke
+  - regression
+# CUJ-001: アプリが起動し、全 6 タブにナビゲートできる。
+---
+- runFlow: '_helpers/launch.yaml'
+
+- tapOn:
+    id: 'tab:closet'
+- assertVisible: 'Closet'
+
+- tapOn:
+    id: 'tab:wishlist'
+- assertVisible: 'Wishlist'
+
+- tapOn:
+    id: 'tab:compare'
+- assertVisible: 'Compare'
+
+- tapOn:
+    id: 'tab:stats'
+- assertVisible: 'Stats'
+
+- tapOn:
+    id: 'tab:settings'
+- assertVisible: 'Settings'
+
+- tapOn:
+    id: 'tab:home'
+- assertVisible: 'Home'

--- a/.maestro/05_reset.yaml
+++ b/.maestro/05_reset.yaml
@@ -1,0 +1,21 @@
+appId: com.sugarshin.seam
+name: reset
+tags:
+  - reset
+# CUJ-026: UI 経由でデータを全削除する (opt-in)。
+# default 実行 (`pnpm test:e2e`) からは tag: reset で除外される。
+# 明示的に `pnpm test:e2e:reset` で実行する。
+---
+- runFlow: '_helpers/launch.yaml'
+- runFlow: '_helpers/goto_settings.yaml'
+- tapOn:
+    id: 'btn:open-data-reset'
+- assertVisible: 'データを全削除'
+- tapOn:
+    id: 'btn:confirm-data-reset'
+- assertVisible: '本当に削除しますか？'
+- tapOn:
+    text: '削除する'
+- assertVisible: '削除しました'
+- tapOn:
+    text: 'OK'

--- a/.maestro/10_item_lifecycle.yaml
+++ b/.maestro/10_item_lifecycle.yaml
@@ -1,0 +1,93 @@
+appId: com.sugarshin.seam
+name: item_lifecycle
+tags:
+  - core
+  - regression
+# CUJ-002,003,004,005,006,011: Owned Item の create → detail → edit → wear log
+# add → wear log delete → item delete までを 1 アイテムで通す。
+# 各 flow は累積 DB 前提。固定名 "E_Item_Lifecycle" を使う (再実行で重複 OK)。
+---
+- runFlow: '_helpers/launch.yaml'
+
+# CUJ-002: Item 新規作成
+- runFlow:
+    file: '_helpers/create_item.yaml'
+    env:
+      itemName: 'E_Item_Lifecycle'
+
+# CUJ-003: Item 詳細表示 (Closet にいる前提でカードを tap)
+- tapOn:
+    text: '.*E_Item_Lifecycle.*'
+- assertVisible: '.*E_Item_Lifecycle.*'
+- assertVisible: '詳細'
+
+# CUJ-004: Item 編集 (名前変更)
+- scrollUntilVisible:
+    element:
+      id: 'btn:edit'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:edit'
+- assertVisible: '編集'
+- tapOn:
+    id: 'field:item-name'
+- eraseText: 32
+- inputText: 'E_Item_Lifecycle_Edited'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:submit'
+    direction: DOWN
+    timeout: 15000
+    speed: 80
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:submit'
+- assertVisible: '.*E_Item_Lifecycle_Edited.*'
+
+# CUJ-005: 着用記録 追加
+- tapOn:
+    id: 'btn:add-wear-log'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:wear-log'
+    timeout: 5000
+- tapOn:
+    id: 'modal:wear-log:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:wear-log'
+    timeout: 5000
+- assertVisible: '着用回数'
+- assertVisible: '1 回'
+
+# CUJ-006: 着用記録 削除 (P2)
+- tapOn:
+    id: 'card:wear-log:.*:delete'
+- extendedWaitUntil:
+    visible: 'この記録を削除しますか？'
+    timeout: 5000
+- tapOn:
+    text: '削除する'
+- extendedWaitUntil:
+    visible: '未着用です'
+    timeout: 5000
+
+# CUJ-011: Item 削除 → 確認ダイアログ → Closet に戻り該当アイテムが消える
+- scrollUntilVisible:
+    element:
+      id: 'btn:delete'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:delete'
+- assertVisible: '削除しますか？'
+- tapOn:
+    text: '削除する'
+- assertVisible: 'Closet'

--- a/.maestro/15_item_sale.yaml
+++ b/.maestro/15_item_sale.yaml
@@ -1,0 +1,91 @@
+appId: com.sugarshin.seam
+name: item_sale
+tags:
+  - regression
+# CUJ-007,008,009,010: 売却候補トグル / Sold にする / 売却取消 / 失敗ログ追加。
+---
+- runFlow: '_helpers/launch.yaml'
+
+- runFlow:
+    file: '_helpers/create_item.yaml'
+    env:
+      itemName: 'E_Item_Sale'
+
+- tapOn:
+    text: '.*E_Item_Sale.*'
+- assertVisible: '詳細'
+
+# CUJ-007: 売却候補トグル → 売却候補 chip 表示
+- scrollUntilVisible:
+    element:
+      id: 'btn:sell-candidate-toggle'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:sell-candidate-toggle'
+- assertVisible: '売却候補'
+
+# CUJ-010: 失敗ログ追加 (modal)
+- scrollUntilVisible:
+    element:
+      id: 'btn:add-failure-log'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:add-failure-log'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:failure-log'
+    timeout: 5000
+- tapOn:
+    id: 'modal:failure-log:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:failure-log'
+    timeout: 5000
+- assertVisible: '失敗ログ'
+
+# CUJ-008: Sold にする → SaleInfoModal → 保存
+- scrollUntilVisible:
+    element:
+      id: 'btn:mark-sold'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:mark-sold'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:sale-info'
+    timeout: 5000
+- tapOn:
+    id: 'modal:sale-info:field:price'
+- inputText: '5000'
+- tapOn:
+    point: '50%, 18%'
+- tapOn:
+    id: 'modal:sale-info:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:sale-info'
+    timeout: 5000
+- assertVisible: '売却日'
+
+# CUJ-009: 所有中に戻す
+- scrollUntilVisible:
+    element:
+      id: 'btn:unmark-sold'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:unmark-sold'
+- assertVisible: '所有中に戻す'
+- tapOn:
+    text: '戻す'
+- extendedWaitUntil:
+    visible:
+      id: 'btn:mark-sold'
+    timeout: 5000

--- a/.maestro/20_candidate_lifecycle.yaml
+++ b/.maestro/20_candidate_lifecycle.yaml
@@ -1,0 +1,62 @@
+appId: com.sugarshin.seam
+name: candidate_lifecycle
+tags:
+  - core
+  - regression
+# CUJ-012,013,014,015: Candidate create → detail → edit → delete。
+---
+- runFlow: '_helpers/launch.yaml'
+
+# CUJ-012: Candidate 新規作成
+- runFlow:
+    file: '_helpers/create_candidate.yaml'
+    env:
+      candidateName: 'E_Candidate_Lifecycle'
+
+# CUJ-013: Candidate 詳細表示
+- tapOn:
+    text: '.*E_Candidate_Lifecycle.*'
+- assertVisible: '販売情報|終了通知|判定履歴'
+
+# CUJ-014: Candidate 編集 (名前変更)
+- scrollUntilVisible:
+    element:
+      id: 'btn:edit'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:edit'
+- assertVisible: '編集'
+- tapOn:
+    id: 'field:item-name'
+- eraseText: 32
+- inputText: 'E_Candidate_Lifecycle_Edited'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:submit'
+    direction: DOWN
+    timeout: 15000
+    speed: 80
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:submit'
+- assertVisible: '.*E_Candidate_Lifecycle_Edited.*'
+
+# CUJ-015: Candidate 削除
+- scrollUntilVisible:
+    element:
+      id: 'btn:delete'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:delete'
+- assertVisible: '削除しますか？'
+- tapOn:
+    text: '削除する'
+- assertVisible: 'Wishlist'

--- a/.maestro/25_decision_buy.yaml
+++ b/.maestro/25_decision_buy.yaml
@@ -1,0 +1,47 @@
+appId: com.sugarshin.seam
+name: decision_buy
+tags:
+  - core
+  - regression
+# CUJ-016: Buy 決定 → owned 昇格 → Closet に表示。
+---
+- runFlow: '_helpers/launch.yaml'
+
+# Setup: candidate を作成
+- runFlow:
+    file: '_helpers/create_candidate.yaml'
+    env:
+      candidateName: 'E_Buy_Decision'
+
+# CUJ-016: Buy 決定 → DecisionReasonModal → 記録 → Closet に owned で表示
+- tapOn:
+    text: '.*E_Buy_Decision.*'
+- scrollUntilVisible:
+    element:
+      id: 'btn:decision-buy'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:decision-buy'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+- tapOn:
+    id: 'modal:decision-reason:field:reason'
+- inputText: 'サイズ良し / 価格妥当'
+- tapOn:
+    id: 'modal:decision-reason:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+
+# 昇格確認: 詳細画面で「所有中」chip が見えれば OK
+- assertVisible: '所有中'
+
+# Closet にも反映されるか確認 (cold restart で tab bar に戻る)
+- runFlow: '_helpers/launch.yaml'
+- runFlow: '_helpers/goto_closet.yaml'
+- assertVisible: '.*E_Buy_Decision.*'

--- a/.maestro/26_decision_other.yaml
+++ b/.maestro/26_decision_other.yaml
@@ -1,0 +1,90 @@
+appId: com.sugarshin.seam
+name: decision_other
+tags:
+  - regression
+# CUJ-017,018,019: Watch / Skip / Lost Auction 決定の記録。
+# 3 つの candidate を作って各 decision を記録 (それぞれ別 row)。
+---
+- runFlow: '_helpers/launch.yaml'
+
+# === CUJ-017: Watch 決定 ===
+- runFlow:
+    file: '_helpers/create_candidate.yaml'
+    env:
+      candidateName: 'E_Watch_Decision'
+- tapOn:
+    text: '.*E_Watch_Decision.*'
+- scrollUntilVisible:
+    element:
+      id: 'btn:decision-watch'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:decision-watch'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+- tapOn:
+    id: 'modal:decision-reason:field:reason'
+- inputText: '価格様子見'
+- tapOn:
+    id: 'modal:decision-reason:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+- assertVisible: 'Watch'
+
+# === CUJ-018: Skip 決定 ===
+- runFlow:
+    file: '_helpers/create_candidate.yaml'
+    env:
+      candidateName: 'E_Skip_Decision'
+- tapOn:
+    text: '.*E_Skip_Decision.*'
+- scrollUntilVisible:
+    element:
+      id: 'btn:decision-skip'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:decision-skip'
+- extendedWaitUntil:
+    visible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+- tapOn:
+    id: 'modal:decision-reason:field:reason'
+- inputText: '被り懸念'
+- tapOn:
+    id: 'modal:decision-reason:submit'
+- extendedWaitUntil:
+    notVisible:
+      id: 'modal:decision-reason'
+    timeout: 5000
+- assertVisible: 'Skip'
+
+# === CUJ-019: Lost Auction 決定 (P2) ===
+- runFlow:
+    file: '_helpers/create_candidate.yaml'
+    env:
+      candidateName: 'E_Lost_Decision'
+- tapOn:
+    text: '.*E_Lost_Decision.*'
+- scrollUntilVisible:
+    element:
+      id: 'btn:decision-lost'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:decision-lost'
+- assertVisible: '落札失敗にする'
+- tapOn:
+    text: '変更'
+- extendedWaitUntil:
+    visible: '落札失敗'
+    timeout: 5000

--- a/.maestro/30_compare_stats.yaml
+++ b/.maestro/30_compare_stats.yaml
@@ -1,0 +1,41 @@
+appId: com.sugarshin.seam
+name: compare_stats
+tags:
+  - regression
+# CUJ-020,021,022: Compare 表示 / Stats 表示 / Stats→Closet 売却モード遷移。
+# 前提: 別 flow で item / candidate が作られていること。
+# (10_item_lifecycle / 20_candidate_lifecycle / 15_item_sale を先に走らせる前提)
+---
+- runFlow: '_helpers/launch.yaml'
+
+# CUJ-020: Compare タブで candidate を選んでスコア / 差分セクションを表示
+- tapOn:
+    id: 'tab:compare'
+- assertVisible: 'Compare'
+- runFlow:
+    when:
+      visible:
+        id: 'picker:compare-candidate'
+    commands:
+      - tapOn:
+          id: 'picker:compare-candidate'
+      - assertVisible: '候補を選択'
+      - tapOn:
+          text: 'キャンセル'
+
+# CUJ-021: Stats タブが crash せず表示
+- tapOn:
+    id: 'tab:stats'
+- assertVisible: 'Stats'
+- assertVisible: 'ワードローブ概要|所有数'
+
+# CUJ-022: Stats → 売却済み StatCard → Closet (sold mode)
+- runFlow:
+    when:
+      visible:
+        id: 'stat:sold'
+    commands:
+      - tapOn:
+          id: 'stat:sold'
+      - assertVisible: 'Closet'
+      - assertVisible: '売却済み'

--- a/.maestro/40_settings.yaml
+++ b/.maestro/40_settings.yaml
@@ -1,0 +1,137 @@
+appId: com.sugarshin.seam
+name: settings
+tags:
+  - regression
+# CUJ-023,024: 個人ルール 追加 + 削除 / ブランドガイド 追加 + 編集 + 削除。
+---
+- runFlow: '_helpers/launch.yaml'
+
+# === CUJ-023: 個人ルール ===
+- runFlow: '_helpers/goto_settings.yaml'
+- tapOn:
+    id: 'btn:open-measurement-rules'
+- assertVisible: '個人ルール'
+
+# rule 追加
+- tapOn:
+    id: 'picker:rule-category'
+- tapOn:
+    id: 'option:rule-category:t_shirt'
+- tapOn:
+    id: 'picker:rule-measurement-key'
+- tapOn:
+    text: '肩幅'
+- tapOn:
+    id: 'picker:rule-operator'
+- tapOn:
+    text: '<'
+- tapOn:
+    id: 'field:rule-value'
+- inputText: '40'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- tapOn:
+    id: 'picker:rule-severity'
+- tapOn:
+    text: 'Warning'
+- tapOn:
+    id: 'field:rule-message'
+- inputText: 'E2E test rule'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:add-rule'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:add-rule'
+- assertVisible: 'E2E test rule'
+
+# rule 削除
+- scrollUntilVisible:
+    element:
+      id: 'card:rule:.*:delete'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'card:rule:.*:delete'
+- assertVisible: '削除しますか？'
+- tapOn:
+    text: '削除する'
+
+# === CUJ-024: ブランドガイド ===
+# 個人ルール画面 (Stack push) から tabs に戻すため cold restart
+- runFlow: '_helpers/launch.yaml'
+- runFlow: '_helpers/goto_settings.yaml'
+- tapOn:
+    id: 'btn:open-brand-guides'
+- assertVisible: 'ブランドガイド'
+
+# brand guide 追加
+- tapOn:
+    id: 'field:guide-brand'
+- inputText: 'E2E_Brand'
+- tapOn:
+    id: 'field:guide-title'
+- inputText: 'E2E ガイド'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:add-brand-guide'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:add-brand-guide'
+- extendedWaitUntil:
+    visible:
+      id: 'card:brand-guide:.*'
+    timeout: 5000
+
+# brand guide 編集 (タイトル変更)
+- tapOn:
+    id: 'card:brand-guide:.*'
+- assertVisible: 'ガイド編集'
+- tapOn:
+    id: 'field:guide-title'
+- eraseText: 32
+- inputText: 'E2E ガイド (編集後)'
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:save-brand-guide'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:save-brand-guide'
+- extendedWaitUntil:
+    visible:
+      id: 'card:brand-guide:.*'
+    timeout: 5000
+
+# brand guide 削除
+- scrollUntilVisible:
+    element:
+      id: 'card:brand-guide:.*:delete'
+    direction: DOWN
+    timeout: 10000
+    visibilityPercentage: 50
+- tapOn:
+    id: 'card:brand-guide:.*:delete'
+- assertVisible: '削除しますか？'
+- tapOn:
+    text: '削除する'

--- a/.maestro/50_filters.yaml
+++ b/.maestro/50_filters.yaml
@@ -1,0 +1,42 @@
+appId: com.sugarshin.seam
+name: filters
+# regression tag は付けない (視覚確認の補足)
+---
+- runFlow: '_helpers/launch.yaml'
+
+# 前提: Closet に何かしら item がある
+- runFlow:
+    file: '_helpers/create_item.yaml'
+    env:
+      itemName: 'E_Filter_Probe'
+
+# 検索
+- tapOn:
+    id: 'field:closet-search'
+- inputText: 'E_Filter_Probe'
+- tapOn:
+    point: '50%, 18%'
+- assertVisible: '.*E_Filter_Probe.*'
+
+# 検索クリア
+- tapOn:
+    id: 'field:closet-search'
+- eraseText: 32
+- tapOn:
+    point: '50%, 18%'
+
+# 並び替え
+- tapOn:
+    id: 'picker:closet-sort'
+- assertVisible: '並び替え'
+- tapOn:
+    text: 'カテゴリ順'
+- assertVisible: 'Closet'
+
+# カテゴリ chip フィルタ on/off (リスト挙動の簡易確認)
+- tapOn:
+    id: 'chip:category:t_shirt'
+- assertVisible:
+    id: 'card:item:.*'
+- tapOn:
+    id: 'chip:category:t_shirt'

--- a/.maestro/_helpers/create_candidate.yaml
+++ b/.maestro/_helpers/create_candidate.yaml
@@ -1,0 +1,31 @@
+appId: com.sugarshin.seam
+# Required env: candidateName
+# Wishlist タブ → FAB → 名前入力 → status を wishlist (default) のまま保存。
+# Self-contained: cold-start (launch) してから始めるので、呼び出し側の
+# 現在地に依存しない。
+---
+- runFlow: 'launch.yaml'
+- runFlow: 'goto_wishlist.yaml'
+- tapOn:
+    id: 'fab:add-candidate'
+- assertVisible: '購入候補を追加'
+- tapOn:
+    id: 'field:item-name'
+- inputText: ${candidateName}
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:submit'
+    direction: DOWN
+    timeout: 15000
+    speed: 80
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:submit'
+- extendedWaitUntil:
+    visible:
+      id: 'card:candidate:.*'
+    timeout: 5000

--- a/.maestro/_helpers/create_item.yaml
+++ b/.maestro/_helpers/create_item.yaml
@@ -1,0 +1,33 @@
+appId: com.sugarshin.seam
+# Required env: itemName
+# Closet タブ → FAB → 名前入力 → 保存。category は default 't_shirt' のまま、
+# status は default 'owned' のまま。
+# Self-contained: cold-start (launch) してから始めるので、呼び出し側の
+# 現在地に依存しない。
+---
+- runFlow: 'launch.yaml'
+- runFlow: 'goto_closet.yaml'
+- tapOn:
+    id: 'fab:add-item'
+- assertVisible: '新規アイテム'
+- tapOn:
+    id: 'field:item-name'
+- inputText: ${itemName}
+# Tap a safe header-area spot to blur the input and dismiss the keyboard.
+- tapOn:
+    point: '50%, 18%'
+- waitForAnimationToEnd:
+    timeout: 1000
+- scrollUntilVisible:
+    element:
+      id: 'btn:submit'
+    direction: DOWN
+    timeout: 15000
+    speed: 80
+    visibilityPercentage: 50
+- tapOn:
+    id: 'btn:submit'
+- extendedWaitUntil:
+    visible:
+      id: 'card:item:.*'
+    timeout: 5000

--- a/.maestro/_helpers/goto_closet.yaml
+++ b/.maestro/_helpers/goto_closet.yaml
@@ -1,0 +1,5 @@
+appId: com.sugarshin.seam
+---
+- tapOn:
+    id: 'tab:closet'
+- assertVisible: 'Closet'

--- a/.maestro/_helpers/goto_settings.yaml
+++ b/.maestro/_helpers/goto_settings.yaml
@@ -1,0 +1,5 @@
+appId: com.sugarshin.seam
+---
+- tapOn:
+    id: 'tab:settings'
+- assertVisible: 'Settings'

--- a/.maestro/_helpers/goto_wishlist.yaml
+++ b/.maestro/_helpers/goto_wishlist.yaml
@@ -1,0 +1,5 @@
+appId: com.sugarshin.seam
+---
+- tapOn:
+    id: 'tab:wishlist'
+- assertVisible: 'Wishlist'

--- a/.maestro/_helpers/launch.yaml
+++ b/.maestro/_helpers/launch.yaml
@@ -1,0 +1,9 @@
+appId: com.sugarshin.seam
+---
+# Cold start. DB migrations and Home tab visibility are awaited.
+- launchApp:
+    stopApp: true
+- extendedWaitUntil:
+    visible:
+      id: 'tab:home'
+    timeout: 30000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,8 @@ pnpm drizzle:generate     # emit src/db/migrations/*.sql + migrations.js
 pnpm drizzle:check        # validate migration history
 ```
 
-E2E (Maestro, local only — no iOS simulator on CI):
-
-```sh
-maestro test .maestro/                       # run all flows
-maestro test .maestro/10_create_item.yaml    # single flow
-```
+E2E (Maestro): see the **E2E (Maestro)** section below. Run from the repo root
+with `pnpm test:e2e` etc. Local only — never wired into CI.
 
 CI (`.github/workflows/test.yml`) runs, in order, `pnpm format:check`,
 `pnpm -r lint`, `pnpm -r typecheck`, `pnpm -r test`, then a Metro bundle build
@@ -162,6 +158,150 @@ repositories ad hoc in UI code.
 - `src/backup/` — JSON export/import (Zod-validated, supports `merge` and
   `replace` modes), CSV export of `items`, and full data reset. The
   data-reset path also wipes on-disk photo blobs and the last-export tracker.
+
+## E2E (Maestro)
+
+Local-only — no CI hookup (GitHub-hosted Linux runners can't host an iOS
+Simulator). **This suite is the only automated regression net for the app**, so
+treat it as a first-class part of the codebase.
+
+### Prerequisites
+
+- Java 17 (`brew install openjdk@17`). The npm scripts inject `JAVA_HOME`
+  inline, so a one-off shell export isn't needed.
+- Maestro CLI 2.5+ (`brew install mobile-dev-inc/tap/maestro`).
+- Xcode + iOS Simulator booted, and `pnpm --filter @seam/app ios` once to
+  install Seam onto the booted device.
+- Metro running so the dev build picks up code changes (`pnpm --filter @seam/app start`
+  if not already up — `pnpm ios` starts it for you).
+
+The `pnpm test:e2e:precheck` script verifies all of the above and prints
+remediation hints; every `test:e2e*` script runs it implicitly.
+
+### Scripts
+
+```sh
+pnpm test:e2e              # all flows except `reset` (default loop)
+pnpm test:e2e:smoke        # tag: smoke — boots app + visits every tab (~5s)
+pnpm test:e2e:core         # tag: core  — P0 lifecycles + Buy decision (~2 min)
+pnpm test:e2e:regression   # tag: regression — P0+P1+P2 (~5 min)
+pnpm test:e2e:reset        # CUJ-026: UI 経由でデータ全削除 (opt-in、デフォルトから除外)
+pnpm test:e2e:hierarchy    # 現在の Simulator UI ツリーを stdout に dump
+```
+
+### Flow layout
+
+`.maestro/` の命名規則:
+
+- `00_smoke.yaml` — 起動 + 全タブ可視
+- `05_reset.yaml` — UI 経由 DB wipe (`tag: reset`)
+- `10_*` — Item ライフサイクル (CRUD, wear log)
+- `15_*` — Item 売却フロー
+- `20_*` — Candidate ライフサイクル (CRUD)
+- `25_*` / `26_*` — 決定 (Buy / Watch / Skip / Lost)
+- `30_*` — 横断的 read-only 画面 (Compare / Stats)
+- `40_*` — Settings サブ画面 (個人ルール / ブランドガイド)
+- `50_*` — Closet フィルタ (P2、視覚確認補足、regression 外)
+
+`.maestro/_helpers/` 配下のサブフローは `_` 接頭辞で自動探索の対象外。
+`runFlow: '<helper>.yaml'` で呼び、`env:` でパラメータを渡す。
+
+### Selector policy
+
+1. **`id:` (testID) 最優先**。タブ / FAB / フォーム / Picker / Modal アクション /
+   業務動詞ボタン / 動的リスト行はすべて testID を必須とし、文言変更で flow が
+   黙って通る/落ちる事故を防ぐ。
+2. testID は `packages/app/src/utils/testIds.ts` に集約。flow ファイル内の
+   `id: "..."` 文字列は **手書きでこの定数と同期**させる (Maestro 側に import
+   機構が無い)。
+3. `text:` は assert 専用 — Stack header の英字 title (`Closet` / `Wishlist`)
+   や日本語固定見出しに使う。tap には基本使わない。
+4. assertVisible で 部分一致したい場合は明示的に regex 形式 (`'.*${name}.*'`)
+   を書く。Maestro v2.5 の `text:` は accessibilityText に対して期待どおり
+   substring match しないことがある。
+
+### DB state policy
+
+- flow 間で DB を自動 reset しない (累積を許容)。各 flow は固有のフィクスチャ
+  名 (`E_Item_Lifecycle`, `E_Buy_Decision` など) を使うので衝突しない。
+- 完全クリーンが欲しいときだけ `pnpm test:e2e:reset` で UI 経由 wipe を行う。
+  `tag: reset` で default 実行から除外している。
+
+### Known constraints (E2E から除外している領域)
+
+- **JSON / CSV エクスポート** — iOS の Share Sheet を Maestro で操作できない。
+- **JSON インポート** — `expo-document-picker` のシステムダイアログが操作不能。
+- **OS 通知パーミッション** — Simulator 上の `expo-notifications` 動作が不安定。
+- **写真追加** — Photo Library / Camera のシステム UI 経由は省略。
+
+これらは repository / domain の unit test (vitest) でカバーする。
+
+### Self-debug recipe
+
+flow が落ちたら以下を順に試す:
+
+```sh
+# 1. 最新の失敗成果物
+ls -t ~/.maestro/tests | head -1
+
+# 2. screenshot-❌-*.png を Read tool で確認 (実際の画面状態)
+
+# 3. UI tree を dump して selector の真の id/text/accessibilityText を確認
+pnpm test:e2e:hierarchy > /tmp/h.txt
+grep -nE '"(text|accessibilityText)"' /tmp/h.txt | grep -v '""'
+
+# 4. 修正方針:
+#    - testID が見つからない → アプリ側で testID 付与漏れ → testIds.ts 拡張
+#    - text 検索が失敗 → accessibilityText の完全形を確認 → '.*X.*' regex
+#    - submit が見えない → scrollUntilVisible (visibilityPercentage: 50)
+#    - 入力後 modal が誤 open → tapOn point: '50%, 18%' で blur (※ Modal 内では
+#      backdrop tap になるので注意)
+```
+
+## E2E 開発ワークフロー (Claude 運用)
+
+新機能 / UI 変更時は **対応する testID と flow を同 PR に含める**。これは
+Linux CI で simulator が動かない以上、Claude のローカル E2E 実行が唯一の自動
+回帰検出経路だから。
+
+### 新画面・新コンポーネント追加時
+
+1. 機能を実装。
+2. 関連 testID を `packages/app/src/utils/testIds.ts` に追加 (命名:
+   `scope:action:dynamicId`、kebab-case)。
+3. UI 要素に testID prop を渡す:
+   - Button / TextField / Picker / Chip / ItemCard / SegmentedControl /
+     PhotoPicker / EmptyState / StatCard はすべて `testID?: string` を受け取る
+   - Modal の root には固定 testID (`modal:wear-log` 等) を直書き
+   - Picker の trigger 側に `picker:foo` を渡すと、option 行は自動で
+     `option:foo:value` に派生
+4. 既存 flow に組み込めるなら organic に追加。新 CUJ なら新 flow を
+   `<NN>_*.yaml` で作る (NN は既存範囲 10/20/30/40/50 の空き番)。
+5. 必要に応じて `.maestro/_helpers/*.yaml` に共通化。
+6. plan の CUJ 表 (`/Users/shingosato/.claude/plans/cuj-e2e-test-parallel-wreath.md`)
+   と本 CLAUDE.md の表を更新。
+
+### 動作確認の段階
+
+| 変更の規模 | 走らせる flow |
+|---|---|
+| typo / コメント / ドキュメント | (なし or `pnpm test:e2e:smoke`) |
+| 新機能 / UI 変更 / ItemForm 修正 | `pnpm test:e2e:smoke` → `:core` → `:regression` |
+| リファクタ / 依存更新 | `pnpm test:e2e:regression` 必須 |
+| Maestro flow 自体の変更 | 個別 flow を `maestro test .maestro/<name>.yaml` |
+
+### ガッチャ早見表
+
+- **destructive な Alert button のラベルは `削除する` に統一**。背景に `削除`
+  テキスト (Pressable) があると Maestro が後ろを tap してしまう。
+- **ItemCard 等のリスト行に `accessibilityLabel` を付けない**。子の `<Text>`
+  が accessibility tree から消えて assertVisible が effective に動かなくなる。
+- **ItemForm の submit ボタンは ScrollView 末尾**。`tapOn id:'btn:submit'` の
+  前に必ず `scrollUntilVisible visibilityPercentage:50` を入れる。
+- **Stack push 後は tab bar が見えない**。`goto_settings` 等を再呼び出しする
+  前に `_helpers/launch.yaml` で cold restart する。
+- **Decision/Sale/WearLog Modal 内では `point: '50%, 18%'` を絶対に tap しない**。
+  Modal 背景 (backdrop) を tap してしまい cancel になる。
 
 ## Conventions
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,15 @@
     "format:check": "biome format .",
     "dev": "pnpm -r --parallel dev",
     "clean": "pnpm -r clean && rm -rf node_modules",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install",
+    "_e2e": "JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH maestro",
+    "test:e2e:precheck": "node scripts/maestro-precheck.mjs",
+    "test:e2e": "pnpm test:e2e:precheck && pnpm _e2e test --exclude-tags=reset .maestro/",
+    "test:e2e:smoke": "pnpm test:e2e:precheck && pnpm _e2e test --include-tags=smoke .maestro/",
+    "test:e2e:core": "pnpm test:e2e:precheck && pnpm _e2e test --include-tags=core .maestro/",
+    "test:e2e:regression": "pnpm test:e2e:precheck && pnpm _e2e test --include-tags=regression .maestro/",
+    "test:e2e:reset": "pnpm test:e2e:precheck && pnpm _e2e test .maestro/05_reset.yaml",
+    "test:e2e:hierarchy": "pnpm _e2e hierarchy"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",

--- a/scripts/maestro-precheck.mjs
+++ b/scripts/maestro-precheck.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Maestro precheck: verify that the iOS Simulator is booted, the Seam app is
+ * installed, the Maestro CLI exists, and Java 17 is reachable. Print friendly
+ * remediation hints on failure.
+ *
+ * Run via `pnpm test:e2e:precheck` (or implicitly by `test:e2e*` scripts).
+ */
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const BUNDLE_ID = 'com.sugarshin.seam';
+const JAVA_HOME_DEFAULT = '/opt/homebrew/opt/openjdk@17';
+
+const fail = (msg) => {
+  console.error(`\n❌  ${msg}\n`);
+  process.exit(1);
+};
+
+const ok = (msg) => console.log(`✅  ${msg}`);
+
+const tryExec = (cmd) => {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+  } catch (err) {
+    return null;
+  }
+};
+
+// 1. maestro CLI
+const maestroPath = tryExec('which maestro')?.trim();
+if (!maestroPath) {
+  fail(
+    [
+      'maestro CLI が見つかりません。',
+      '  brew install mobile-dev-inc/tap/maestro',
+      'またはガイド: https://docs.maestro.dev/get-started/quickstart',
+    ].join('\n'),
+  );
+}
+ok(`maestro CLI: ${maestroPath}`);
+
+// 2. Java 17
+const javaHome = process.env.JAVA_HOME ?? JAVA_HOME_DEFAULT;
+if (!existsSync(`${javaHome}/bin/java`)) {
+  fail(
+    [
+      `Java 17 が ${javaHome} に見つかりません。`,
+      '  brew install openjdk@17',
+      `または JAVA_HOME を 17 にセットしてください (現在: ${process.env.JAVA_HOME ?? 'unset'})`,
+    ].join('\n'),
+  );
+}
+ok(`Java 17: ${javaHome}`);
+
+// 3. iOS Simulator booted
+const bootedOut = tryExec('xcrun simctl list devices booted') ?? '';
+if (!/\(Booted\)/.test(bootedOut)) {
+  fail(
+    [
+      '起動中の iOS Simulator が見つかりません。',
+      '  open -a Simulator',
+      'または Xcode から iPhone デバイスを起動してください。',
+    ].join('\n'),
+  );
+}
+ok('iOS Simulator: booted');
+
+// 4. Seam app installed
+const containerOut = tryExec(`xcrun simctl get_app_container booted ${BUNDLE_ID} 2>/dev/null`);
+if (!containerOut) {
+  fail(
+    [
+      `Simulator に Seam (${BUNDLE_ID}) がインストールされていません。`,
+      '  cd packages/app && pnpm ios',
+      'で dev build を install してください。',
+    ].join('\n'),
+  );
+}
+ok(`Seam app installed: ${containerOut.trim()}`);
+
+console.log('\n✨  precheck OK — Maestro を実行できます。\n');


### PR DESCRIPTION
## Summary

- 26 個の CUJ を新規定義し、`.maestro/` 上の **9 本の flow + 6 本の helper** に再編成。Maestro v2.5 / iPhone 17 Pro / iOS 26.4 simulator で **8/8 regression PASS** (約 6 分)
- `pnpm test:e2e` 系スクリプトと precheck (`scripts/maestro-precheck.mjs`) を追加し、Java 17 自動 export + Simulator/Seam install/Maestro CLI 検証で 1 コマンド実行できるように
- CLAUDE.md に **E2E (Maestro)** + **E2E 開発ワークフロー** セクションを新設し、self-debug recipe とガッチャ早見表を明文化

## Background

旧 `.maestro/` の flow 3 本は長らくメンテされておらず、現行 UI と乖離して **1 ステップ目から落ちる**状態だった。実機で動かして特定した根本原因:

1. `(tabs)/_layout.tsx` の `tabBarAccessibilityLabel: 'Closet タブ'` が text を上書きし `text:""` になる → `tapOn: 'Closet'` が効かない
2. Closet/Wishlist の FAB が **全角 `＋` (U+FF0B)** で書かれており、flow の regex `\+` (半角) に一致しない
3. `ItemForm` のラベルが `アイテム名` → `名前` に変わっている
4. アプリ全体で `testID` が **0 個**だった

ユーザー指示で「Claude (= AI agent) が新機能開発時とリグレッション観点で日常的に実行する」前提を踏まえ、文言依存ではなく testID ベースの安定 selector へ全面書き換えた。

## Scope of this PR

testID インフラ (`packages/app/src/utils/testIds.ts` と各コンポーネントへの `testID` prop 追加) は **#73 (dark mode coverage) で main に取り込み済み**。本 PR はそれと重複しない以下の Maestro 専用部分だけを含む:

- `.maestro/` 配下の 9 flow + 6 helper (旧 `.gitignore` で ignore されていたが本 PR で track 化)
- `scripts/maestro-precheck.mjs` (Simulator / Java 17 / Seam install / Maestro CLI を一括 precheck)
- `package.json` への `pnpm test:e2e[:smoke|:core|:regression|:reset|:hierarchy]` script 追加
- `CLAUDE.md` への E2E (Maestro) + E2E 開発ワークフロー セクション追加

## CUJ 一覧 (26 件 / 9 flow)

| flow | 含む CUJ | tags |
|---|---|---|
| `00_smoke.yaml` | CUJ-001 (タブ起動 + 全タブ可視) | `smoke`, `regression` |
| `05_reset.yaml` | CUJ-026 (UI 経由 DB wipe / opt-in) | `reset` |
| `10_item_lifecycle.yaml` | CUJ-002〜006, 011 (Item create/detail/edit/着用記録 add+delete/delete) | `core`, `regression` |
| `15_item_sale.yaml` | CUJ-007〜010 (売却候補トグル / Sold / 売却取消 / 失敗ログ) | `regression` |
| `20_candidate_lifecycle.yaml` | CUJ-012〜015 (Candidate CRUD) | `core`, `regression` |
| `25_decision_buy.yaml` | CUJ-016 (Buy 決定 → owned 昇格) | `core`, `regression` |
| `26_decision_other.yaml` | CUJ-017〜019 (Watch / Skip / Lost Auction) | `regression` |
| `30_compare_stats.yaml` | CUJ-020〜022 (Compare / Stats 表示 / Stats→Closet 遷移) | `regression` |
| `40_settings.yaml` | CUJ-023〜024 (個人ルール 追加+削除 / ブランドガイド 追加+編集+削除) | `regression` |
| `50_filters.yaml` | CUJ-025 (Closet 検索 / 並び替え / chip filter) | (regression 外、視覚補足) |

## 実行方法

\`\`\`sh
pnpm test:e2e:smoke        # 起動 + 全タブ (~5s)
pnpm test:e2e:core         # P0 critical path (~2 min)
pnpm test:e2e:regression   # P0+P1+P2 全部 (~5-6 min)
pnpm test:e2e              # reset 除く全 flow
pnpm test:e2e:reset        # opt-in: UI 経由データ全削除
pnpm test:e2e:hierarchy    # debug 用 UI tree dump
\`\`\`

precheck (`pnpm test:e2e:precheck`) が iOS Simulator booted / Seam install / Maestro CLI / Java 17 を自動検証し、不足を分かりやすく案内する。

## Test plan

- [x] \`pnpm typecheck\` (3 packages, 全 PASS)
- [x] \`pnpm lint\` (eslint --max-warnings 0 で PASS)
- [x] \`pnpm format:check\` (Biome、変更なし)
- [x] \`pnpm test\` (vitest: domain 144 / app 43 = 187 PASS)
- [x] \`pnpm test:e2e:regression\` → **8/8 flows PASS** (6m18s on iPhone 17 Pro / iOS 26.4 simulator)
- [x] **#73 dark mode 取り込み後の最新 main で再検証** → flow に影響なし、引き続き 8/8 PASS

## Out of scope (E2E から除外している領域)

iOS のシステム UI (Share Sheet / DocumentPicker / Notification permission) を Maestro で操作できないため、以下は repository / domain unit test に責任を持たせる:

- JSON / CSV エクスポート (Share Sheet)
- JSON インポート (DocumentPicker)
- リマインダー設定 (notification permission)
- 写真追加 (Photo Library / Camera)

## Notes

- CI (`.github/workflows/test.yml`, Linux runner) には **Maestro を組み込んでいない**。GitHub Actions macOS runner で動かす workflow は別 PR で対応予定 (詳細プランは別途整備済)。
- testID 集約定数 `packages/app/src/utils/testIds.ts` と各コンポーネントへの testID 付与は **#73 で main にマージ済**のため本 PR には含まれない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)