### PR TITLE
fix(app): apply dark-mode palette to native stack and tabs headers

### DIFF
--- a/packages/app/app/(tabs)/_layout.tsx
+++ b/packages/app/app/(tabs)/_layout.tsx
@@ -10,6 +10,8 @@ export default function TabsLayout() {
         headerShown: true,
         headerStyle: { backgroundColor: palette.bg },
         headerTintColor: palette.text,
+        headerTitleStyle: { color: palette.text },
+        headerShadowVisible: false,
         tabBarStyle: {
           backgroundColor: palette.bg,
           borderTopColor: palette.border,

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -75,6 +75,10 @@ export default function RootLayout() {
         screenOptions={{
           headerShown: false,
           headerBackButtonDisplayMode: 'minimal',
+          headerStyle: { backgroundColor: palette.bg },
+          headerTintColor: palette.text,
+          headerTitleStyle: { color: palette.text },
+          headerShadowVisible: false,
           contentStyle: { backgroundColor: palette.bg },
         }}
       >


### PR DESCRIPTION
## Summary

- Detail screens (`item/[id]`, `candidate/[id]`) shipped a white iOS-default header in dark mode because the root `<Stack screenOptions>` in `app/_layout.tsx` only carried `contentStyle`, leaving `headerStyle` / `headerTintColor` / `headerTitleStyle` unset.
- Move the palette-aware header styling onto the root Stack so every pushed screen (`item/new`, `candidate/new`, `settings/measurement-rules`, `settings/data-reset`, `settings/brand-guides/*`, the two detail screens) inherits `palette.bg` / `palette.text` automatically. Also disable `headerShadowVisible` to drop the hairline that becomes a bright line on `#0E0E0E`.
- Mirror the same `headerTitleStyle` + `headerShadowVisible: false` on `(tabs)/_layout.tsx` so tab headers and stack headers stay visually consistent when switching between them.

## Background

User report: 「ダークモードのときに最上部が白のままで対応されてない」(screenshots showed the back chevron + 編集 button rendered on a white bar above the otherwise-dark item / candidate detail page).

I audited the codebase for related dark-mode gaps:

- All tab / detail / settings screens already consume `useThemeColors()`; only the navigator chrome was missing palette wiring.
- The remaining hex literals are intentional: `ImageViewerModal` uses a fixed black backdrop with white chrome regardless of theme; `compare.tsx`, `SeverityBadge.tsx`, `ScoreBadge.tsx` already branch on `p.bg === '#0E0E0E'` to tint badges; modals use `rgba(0,0,0,0.4)` overlays; `shadowColor: '#000'` is correct for both modes.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm -r lint`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r test` (passed via pre-push: shared 11/11, domain 144/144, app 43/43)
- [ ] iOS Simulator: toggle Settings → Developer → Dark Appearance, open item detail and candidate detail, confirm the header bar matches `palette.bg` (#0E0E0E) and the back chevron / 編集 / title text are `palette.text` (#F2F2F2). Repeat for `item/new`, `candidate/new`, settings sub-screens.
- [ ] Toggle back to light mode and confirm no regression — header should still read `#FFFFFF` / `#1A1A1A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)