### PR TITLE
fix(app): stop header tint flicker on detail screen push

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -7,13 +7,21 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ActivityIndicator, Text, View } from 'react-native';
 import { useDbMigrations } from '../src/db/migrate';
 import { configureNotificationHandler } from '../src/notifications';
-import { font, space, useThemeColors } from '../src/theme';
+import { ThemeProvider, font, space, useThemeColors } from '../src/theme';
 
 // Configure foreground notification presentation once on module load. Safe to
 // call multiple times — Expo replaces the handler each time.
 configureNotificationHandler();
 
 export default function RootLayout() {
+  return (
+    <ThemeProvider>
+      <RootLayoutInner />
+    </ThemeProvider>
+  );
+}
+
+function RootLayoutInner() {
   const { success, error } = useDbMigrations();
   const palette = useThemeColors();
 
@@ -73,7 +81,13 @@ export default function RootLayout() {
       <StatusBar style="auto" />
       <Stack
         screenOptions={{
-          headerShown: false,
+          // Default headerShown:true so pushed routes (item/[id], candidate/[id],
+          // settings/*) have their native header configured with the palette
+          // tint and background from the moment the push begins. Letting each
+          // screen flip headerShown:false→true via setOptions later caused the
+          // back/edit buttons to flicker between light- and dark-mode tints
+          // mid-transition.
+          headerShown: true,
           headerBackButtonDisplayMode: 'minimal',
           headerStyle: { backgroundColor: palette.bg },
           headerTintColor: palette.text,
@@ -82,7 +96,7 @@ export default function RootLayout() {
           contentStyle: { backgroundColor: palette.bg },
         }}
       >
-        <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       </Stack>
     </GestureHandlerRootView>
   );

--- a/packages/app/app/candidate/[id].tsx
+++ b/packages/app/app/candidate/[id].tsx
@@ -509,9 +509,33 @@ export default function CandidateDetailScreen() {
     </View>
   );
 
+  // Compute the native-stack options for *every* render path, so the iOS
+  // header has its title / right action configured the moment the screen is
+  // pushed — not after the async refresh resolves. Registering the options
+  // late was the visible cause of the back/edit button tint flicker during
+  // push transitions.
+  const screenOptions = editing
+    ? { title: '編集', headerRight: () => null }
+    : {
+        title: loaded?.item.name ?? '',
+        headerRight: loaded
+          ? () => (
+              <Text
+                accessibilityRole="button"
+                testID={testIds.btn.edit}
+                onPress={() => setEditing(true)}
+                style={styles.editLink}
+              >
+                編集
+              </Text>
+            )
+          : () => null,
+      };
+
   if (!itemId) {
     return (
       <View style={styles.center}>
+        <Stack.Screen options={screenOptions} />
         <Text style={styles.muted}>不正な ID です</Text>
       </View>
     );
@@ -520,6 +544,7 @@ export default function CandidateDetailScreen() {
   if (!loaded) {
     return (
       <View style={styles.center}>
+        <Stack.Screen options={screenOptions} />
         <ActivityIndicator color={palette.text} />
       </View>
     );
@@ -529,7 +554,7 @@ export default function CandidateDetailScreen() {
     const c = loaded.candidate;
     return (
       <View style={{ flex: 1, backgroundColor: palette.bg }}>
-        <Stack.Screen options={{ title: '編集', headerShown: true, headerRight: () => null }} />
+        <Stack.Screen options={screenOptions} />
         <ItemForm
           itemId={itemId}
           tagSuggestions={tagSuggestions}
@@ -605,22 +630,7 @@ export default function CandidateDetailScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen
-        options={{
-          title: loaded.item.name,
-          headerShown: true,
-          headerRight: () => (
-            <Text
-              accessibilityRole="button"
-              testID={testIds.btn.edit}
-              onPress={() => setEditing(true)}
-              style={styles.editLink}
-            >
-              編集
-            </Text>
-          ),
-        }}
-      />
+      <Stack.Screen options={screenOptions} />
       <ScrollView
         style={{ flex: 1 }}
         contentContainerStyle={{ paddingBottom: space.xxl + insets.bottom }}

--- a/packages/app/app/candidate/new.tsx
+++ b/packages/app/app/candidate/new.tsx
@@ -37,7 +37,7 @@ export default function NewCandidateScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen options={{ title: '購入候補を追加', headerShown: true }} />
+      <Stack.Screen options={{ title: '購入候補を追加' }} />
       <ItemForm
         tagSuggestions={tagSuggestions}
         submitting={submitting}

--- a/packages/app/app/item/[id].tsx
+++ b/packages/app/app/item/[id].tsx
@@ -375,9 +375,32 @@ export default function ItemDetailScreen() {
     </View>
   );
 
+  // Compute the native-stack options for *every* render path, so the iOS
+  // header has its title / right action configured the moment the screen is
+  // pushed — not after the async refresh resolves. Registering the options
+  // late was the visible cause of the back/edit button tint flicker during
+  // push transitions.
+  const screenOptions = editing
+    ? { title: '編集', headerRight: () => null }
+    : {
+        title: loaded?.item.name ?? '',
+        headerRight: loaded
+          ? () => (
+              <Text
+                accessibilityRole="button"
+                onPress={() => setEditing(true)}
+                style={styles.editLink}
+              >
+                編集
+              </Text>
+            )
+          : () => null,
+      };
+
   if (!itemId) {
     return (
       <View style={styles.center}>
+        <Stack.Screen options={screenOptions} />
         <Text style={styles.muted}>不正な ID です</Text>
       </View>
     );
@@ -386,6 +409,7 @@ export default function ItemDetailScreen() {
   if (!loaded) {
     return (
       <View style={styles.center}>
+        <Stack.Screen options={screenOptions} />
         <ActivityIndicator color={palette.text} />
       </View>
     );
@@ -394,7 +418,7 @@ export default function ItemDetailScreen() {
   if (editing) {
     return (
       <View style={{ flex: 1, backgroundColor: palette.bg }}>
-        <Stack.Screen options={{ title: '編集', headerShown: true, headerRight: () => null }} />
+        <Stack.Screen options={screenOptions} />
         <ItemForm
           itemId={itemId}
           tagSuggestions={tagSuggestions}
@@ -469,21 +493,7 @@ export default function ItemDetailScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen
-        options={{
-          title: loaded.item.name,
-          headerShown: true,
-          headerRight: () => (
-            <Text
-              accessibilityRole="button"
-              onPress={() => setEditing(true)}
-              style={styles.editLink}
-            >
-              編集
-            </Text>
-          ),
-        }}
-      />
+      <Stack.Screen options={screenOptions} />
       <ScrollView
         style={{ flex: 1 }}
         contentContainerStyle={{ paddingBottom: space.xxl + insets.bottom }}

--- a/packages/app/app/item/new.tsx
+++ b/packages/app/app/item/new.tsx
@@ -37,7 +37,7 @@ export default function NewItemScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen options={{ title: '新規アイテム', headerShown: true }} />
+      <Stack.Screen options={{ title: '新規アイテム' }} />
       <ItemForm
         tagSuggestions={tagSuggestions}
         submitting={submitting}

--- a/packages/app/app/settings/brand-guides/[id].tsx
+++ b/packages/app/app/settings/brand-guides/[id].tsx
@@ -138,7 +138,7 @@ export default function BrandGuideEditScreen() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       keyboardVerticalOffset={insets.top + 44}
     >
-      <Stack.Screen options={{ title: 'ガイド編集', headerShown: true }} />
+      <Stack.Screen options={{ title: 'ガイド編集' }} />
       <ScrollView
         contentContainerStyle={{ padding: space.lg, paddingBottom: space.xxl }}
         keyboardDismissMode="on-drag"

--- a/packages/app/app/settings/brand-guides/index.tsx
+++ b/packages/app/app/settings/brand-guides/index.tsx
@@ -111,7 +111,7 @@ export default function BrandGuidesScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen options={{ title: 'ブランドガイド', headerShown: true }} />
+      <Stack.Screen options={{ title: 'ブランドガイド' }} />
       <ScrollView contentContainerStyle={{ paddingBottom: space.xxl }}>
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>新規追加</Text>

--- a/packages/app/app/settings/data-reset.tsx
+++ b/packages/app/app/settings/data-reset.tsx
@@ -48,7 +48,7 @@ export default function DataResetScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen options={{ title: 'データを全削除', headerShown: true }} />
+      <Stack.Screen options={{ title: 'データを全削除' }} />
       <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }}>
         <View style={styles.warningCard}>
           <Text style={styles.warningTitle}>すべてのデータが消えます</Text>

--- a/packages/app/app/settings/measurement-rules.tsx
+++ b/packages/app/app/settings/measurement-rules.tsx
@@ -149,7 +149,7 @@ export default function MeasurementRulesScreen() {
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
-      <Stack.Screen options={{ title: '個人ルール', headerShown: true }} />
+      <Stack.Screen options={{ title: '個人ルール' }} />
       <ScrollView contentContainerStyle={{ paddingBottom: space.xxl }}>
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>新規追加</Text>

--- a/packages/app/src/theme/index.ts
+++ b/packages/app/src/theme/index.ts
@@ -1,3 +1,4 @@
+import { createContext, createElement, useContext, type ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
 
 /**
@@ -53,16 +54,24 @@ export const colors = lightColors;
 
 export type ColorToken = keyof typeof lightColors;
 
-/**
- * React hook returning the active color palette for the current OS-level
- * appearance setting. Use this in screens that should follow dark mode.
- * For static StyleSheet declarations the existing `colors` export still
- * resolves to the light palette — that's fine for now (Phase 9 only adapts
- * a representative subset of screens).
- */
-export const useThemeColors = (): ColorPalette => {
+// Single subscription point for the OS color scheme. Subscribing inside every
+// screen via `useColorScheme()` was causing brief light/dark mismatches across
+// screens during native-stack push transitions: a freshly-mounted detail
+// screen would briefly compute a different palette than the already-mounted
+// root layout, and the iOS native header re-styled mid-animation as the
+// per-screen subscription caught up. Funnelling the subscription through a
+// single ThemeProvider at the app root keeps every consumer in lockstep.
+const ThemeContext = createContext<ColorPalette | null>(null);
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const scheme = useColorScheme();
-  return scheme === 'dark' ? darkColors : lightColors;
+  const palette = scheme === 'dark' ? darkColors : lightColors;
+  return createElement(ThemeContext.Provider, { value: palette }, children);
+};
+
+export const useThemeColors = (): ColorPalette => {
+  const ctx = useContext(ThemeContext);
+  return ctx ?? lightColors;
 };
 
 export const space = {


### PR DESCRIPTION
## Summary
- Closet/Wishlist 詳細に push したとき、戻るボタンと編集ボタンが light-mode 用と dark-mode 用の色を 1〜2 回行き来してから期待色に落ち着く flicker を解消
- `useColorScheme()` の購読を root に集約し、`<Stack.Screen options>` を loading フェーズから登録するよう構造変更

## Background
recent fix (#77 / 59c15d8) で root Stack の screenOptions に palette を当てたが、push transition 中に back/edit ボタンの tint がライト⇄ダークで点滅する問題が残っていた。原因は 3 段重ね:

1. root Stack の `screenOptions.headerShown` は `false` のまま、各画面が body 内 `<Stack.Screen options={{ headerShown: true, ... }}>` で後追いで true に切り替えていたため、iOS が header 非表示で push を開始 → mount 後に setOptions で再構成され、palette tint が当たる前にデフォルトヘッダーが見えていた
2. `useThemeColors()` が各コンポーネント独立に `useColorScheme()` を購読しており、新たに mount される screen が一瞬 root と異なる palette を計算 → headerRight (編集 Text) の色が `palette.text` のライト/ダーク間で振動
3. detail 画面の `<Stack.Screen>` は `loaded` が non-null になってから初めて render されるため、setOptions が push transition 完了後にずれ込みヘッダーがその後で再構成

## Fix
- `src/theme/index.ts`: `ThemeProvider` を新設し `useColorScheme()` の購読を root の 1 箇所に集約。`useThemeColors()` は context から palette を取得
- `app/_layout.tsx`: `ThemeProvider` でラップし、`screenOptions.headerShown` を `true` をデフォルトに反転、`(tabs)` のみ `headerShown: false` を明示
- `app/item/[id].tsx`, `app/candidate/[id].tsx`: `screenOptions` を early return の外で導出し、`!itemId` / `!loaded` / `editing` / 通常表示すべての分岐で `<Stack.Screen options={screenOptions} />` を render。loading 中も title/headerRight が確定する
- `app/item/new.tsx`, `app/candidate/new.tsx`, `app/settings/{data-reset,measurement-rules,brand-guides/index,brand-guides/[id]}.tsx`: 冗長な `headerShown: true` を削除

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm format:check` (CI 相当)
- [ ] Simulator: ライトモードで Closet → アイテム詳細 → 戻る、Wishlist → 候補詳細 → 戻るで back/編集の色が点滅しないこと
- [ ] Simulator: ダークモードで同上 (期待値: dark palette の light tint で安定)
- [ ] Simulator: 設定 → データを全削除 / 個人ルール / ブランドガイドへの push でも header の色が一定であること
- [ ] (任意) `pnpm test:e2e:smoke` (タブ可視性の sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)