### PR TITLE
fix(release): drop unspec'd app-level buildVersion from source.json

### DIFF
--- a/.github/scripts/update-source.mjs
+++ b/.github/scripts/update-source.mjs
@@ -37,7 +37,6 @@ const newVersion = {
 app.versions = [newVersion, ...(app.versions || []).filter((v) => v.version !== VERSION)];
 
 app.version = newVersion.version;
-app.buildVersion = newVersion.buildVersion;
 app.versionDate = newVersion.date;
 app.versionDescription = newVersion.localizedDescription;
 app.downloadURL = newVersion.downloadURL;

--- a/docs/source.json
+++ b/docs/source.json
@@ -164,8 +164,7 @@
           "size": 8914597,
           "minOSVersion": "15.1"
         }
-      ],
-      "buildVersion": "13"
+      ]
     }
   ],
   "news": []


### PR DESCRIPTION
## Summary

- App ルート (`apps[0]`) に書かれていた `buildVersion: "12"` は SideStore の `StoreApp.CodingKeys` に存在せず、クライアントが silent に無視する dead data だったため削除
- `update-source.mjs` で同じフィールドを毎リリース再生成していたので、書き込みも止める

## Background

SideStore source の参照実装 ([`AltStoreCore/Model/StoreApp.swift`](https://github.com/SideStore/SideStore)) を確認したところ、`buildVersion` は `AppVersion.CodingKeys` (versions[]) のみに存在し、StoreApp 側には無い。`docs.sidestore.io` も "fully compatible with AltStore Sources" と明言しており、AltStore の canonical source (`apps.altstore.io`) も App ルートに `buildVersion` を持たない。

`apps[0].versions[].buildVersion` は引き続き正しい場所として維持される (新規 release 分のみ。古い entry は `decodeIfPresent` で optional のため backfill 不要)。

## Test plan

- [x] `python3 -c "import json; json.load(open('docs/source.json'))"` で JSON 構文 OK
- [x] `apps[0].buildVersion` が消え、`apps[0].versions[0].buildVersion` は維持
- [x] pre-push hook (`pnpm format:check` / `pnpm -r test` / `pnpm -r typecheck` / `pnpm -r lint`) all green
- [ ] 次回 release で `update-source.mjs` が App ルートに `buildVersion` を再注入しないこと (workflow 実行時に確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)