### PR TITLE
feat: メルカリ商品 URL を Wishlist 追加フォームに取り込む

### DIFF
--- a/packages/app/app/candidate/new.tsx
+++ b/packages/app/app/candidate/new.tsx
@@ -1,18 +1,47 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, View } from 'react-native';
+import { Alert, Text, View } from 'react-native';
 import { Stack, router } from 'expo-router';
-import { ItemForm, type ItemFormSubmit } from '../../src/forms/ItemForm';
+import { ItemForm, type ItemFormDefaults, type ItemFormSubmit } from '../../src/forms/ItemForm';
+import { Button, TextField } from '../../src/components';
 import { createItemWithDetails, tagRepository } from '../../src/repositories';
-import { useThemeColors } from '../../src/theme';
+import { font, space, useThemeColors } from '../../src/theme';
+import { ImportUrlError, importMercariUrl } from '../../src/utils/importMercariUrl';
+import { testIds } from '../../src/utils/testIds';
+
+const INITIAL_DEFAULTS: ItemFormDefaults = { values: { status: 'wishlist' } };
 
 export default function NewCandidateScreen() {
   const palette = useThemeColors();
   const [submitting, setSubmitting] = useState(false);
   const [tagSuggestions, setTagSuggestions] = useState<string[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [importUrl, setImportUrl] = useState('');
+  const [defaults, setDefaults] = useState<ItemFormDefaults>(INITIAL_DEFAULTS);
+  const [formKey, setFormKey] = useState(0);
 
   useEffect(() => {
     void tagRepository.listAll().then((tags) => setTagSuggestions(tags.map((t) => t.name)));
   }, []);
+
+  const handleImport = useCallback(async () => {
+    setImporting(true);
+    try {
+      const next = await importMercariUrl(importUrl);
+      setDefaults(next);
+      setFormKey((k) => k + 1);
+      setImportUrl('');
+    } catch (err) {
+      const msg =
+        err instanceof ImportUrlError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : '取り込みに失敗しました';
+      Alert.alert('取り込み失敗', msg);
+    } finally {
+      setImporting(false);
+    }
+  }, [importUrl]);
 
   const handleSubmit = useCallback(async (input: ItemFormSubmit) => {
     setSubmitting(true);
@@ -38,12 +67,54 @@ export default function NewCandidateScreen() {
   return (
     <View style={{ flex: 1, backgroundColor: palette.bg }}>
       <Stack.Screen options={{ title: '購入候補を追加' }} />
+      <View
+        style={{
+          backgroundColor: palette.surface,
+          paddingHorizontal: space.lg,
+          paddingTop: space.md,
+          paddingBottom: space.md,
+          borderBottomWidth: 1,
+          borderBottomColor: palette.border,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: font.size.xs,
+            color: palette.textMuted,
+            fontWeight: font.weight.semibold,
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            marginBottom: space.sm,
+          }}
+        >
+          URL から取り込み
+        </Text>
+        <TextField
+          value={importUrl}
+          onChangeText={setImportUrl}
+          placeholder="https://jp.mercari.com/item/..."
+          keyboardType="url"
+          autoCapitalize="none"
+          autoCorrect={false}
+          hint="メルカリの商品 URL を貼り付けると名前・価格・画像 1 枚を自動入力します"
+          testID={testIds.field.importUrl}
+        />
+        <Button
+          label="取り込む"
+          onPress={() => void handleImport()}
+          loading={importing}
+          disabled={importUrl.trim() === ''}
+          variant="secondary"
+          testID={testIds.btn.importUrl}
+        />
+      </View>
       <ItemForm
+        key={formKey}
         tagSuggestions={tagSuggestions}
         submitting={submitting}
         submitLabel="登録"
         onSubmit={handleSubmit}
-        defaults={{ values: { status: 'wishlist' } }}
+        defaults={defaults}
         onCancel={() => {
           if (router.canGoBack()) router.back();
         }}

--- a/packages/app/src/utils/fetchProductHtml.ts
+++ b/packages/app/src/utils/fetchProductHtml.ts
@@ -1,0 +1,63 @@
+/**
+ * Fetch a product page's HTML with a mobile Safari User-Agent.
+ *
+ * Mercari は Cloudflare 配下だが、iOS Safari の UA を投げれば素朴な fetch
+ * でも 200 が返る (実機検証済み)。bot 検知が強くなったときに UA を切り替え
+ * られるよう User-Agent はここに集約する。
+ */
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export class FetchProductHtmlError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'FetchProductHtmlError';
+    this.status = status;
+  }
+}
+
+export type FetchProductHtmlOptions = {
+  timeoutMs?: number;
+  userAgent?: string;
+};
+
+export const fetchProductHtml = async (
+  url: string,
+  opts: FetchProductHtmlOptions = {},
+): Promise<string> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'User-Agent': opts.userAgent ?? DEFAULT_USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new FetchProductHtmlError(
+        `ページの取得に失敗しました (HTTP ${res.status})`,
+        res.status,
+      );
+    }
+    return await res.text();
+  } catch (err) {
+    if (err instanceof FetchProductHtmlError) throw err;
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new FetchProductHtmlError('ページの取得がタイムアウトしました');
+    }
+    throw new FetchProductHtmlError(
+      err instanceof Error ? err.message : 'ページの取得に失敗しました',
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/packages/app/src/utils/importMercariUrl.ts
+++ b/packages/app/src/utils/importMercariUrl.ts
@@ -1,0 +1,81 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import {
+  MercariExtractionError,
+  extractMercariFromHtml,
+  parseMercariItemId,
+} from '@seam/domain/extraction';
+import type { ItemFormDefaults } from '../forms/ItemForm';
+import { savePhoto, type SavedPhoto } from '../photos/savePhoto';
+import { newId } from './ids';
+import { fetchProductHtml } from './fetchProductHtml';
+
+const downloadImage = async (imageUrl: string): Promise<SavedPhoto | null> => {
+  const tmpName = `${newId()}.jpg`;
+  const tmpPath = `${FileSystem.cacheDirectory ?? ''}${tmpName}`;
+  try {
+    const result = await FileSystem.downloadAsync(imageUrl, tmpPath);
+    if (result.status !== 200) {
+      await FileSystem.deleteAsync(tmpPath, { idempotent: true });
+      return null;
+    }
+    const saved = await savePhoto(result.uri);
+    await FileSystem.deleteAsync(tmpPath, { idempotent: true });
+    return saved;
+  } catch {
+    await FileSystem.deleteAsync(tmpPath, { idempotent: true });
+    return null;
+  }
+};
+
+export class ImportUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportUrlError';
+  }
+}
+
+/**
+ * Fetch a Mercari item URL and return ItemForm defaults that prefill the
+ * Wishlist creation form. URL のバリデーションが失敗したら ImportUrlError を
+ * 投げる。
+ */
+export const importMercariUrl = async (url: string): Promise<ItemFormDefaults> => {
+  const trimmed = url.trim();
+  if (!parseMercariItemId(trimmed)) {
+    throw new ImportUrlError('メルカリの商品 URL を入力してください');
+  }
+
+  let html: string;
+  try {
+    html = await fetchProductHtml(trimmed);
+  } catch (err) {
+    throw new ImportUrlError(err instanceof Error ? err.message : 'ページ取得に失敗しました');
+  }
+
+  let extraction;
+  try {
+    extraction = extractMercariFromHtml(html, trimmed);
+  } catch (err) {
+    if (err instanceof MercariExtractionError) {
+      throw new ImportUrlError(err.message);
+    }
+    throw err;
+  }
+
+  const photos: SavedPhoto[] = [];
+  if (extraction.primaryImageUrl) {
+    const saved = await downloadImage(extraction.primaryImageUrl);
+    if (saved) photos.push(saved);
+  }
+
+  return {
+    values: {
+      name: extraction.name,
+      status: 'wishlist',
+      sourceType: 'mercari',
+      candidateCurrentPrice: extraction.priceJpy !== undefined ? String(extraction.priceJpy) : '',
+      productUrl: extraction.productUrl,
+    },
+    photos,
+  };
+};

--- a/packages/app/src/utils/testIds.ts
+++ b/packages/app/src/utils/testIds.ts
@@ -58,6 +58,8 @@ export const testIds = {
     guideTitle: id('field:guide-title'),
     guideNotes: id('field:guide-notes'),
     guideChecklist: id('field:guide-checklist'),
+    // URL 取り込み (Wishlist 追加画面)
+    importUrl: id('field:import-url'),
   },
   picker: {
     category: id('picker:category'),
@@ -113,6 +115,7 @@ export const testIds = {
     confirmDataReset: id('btn:confirm-data-reset'),
     addItemFromHomeEmpty: id('btn:home-empty-add-item'),
     sellCandidateToggle: id('btn:sell-candidate-toggle'),
+    importUrl: id('btn:import-url'),
   },
   modal: {
     wearLog: id('modal:wear-log'),

--- a/packages/domain/src/extraction/index.ts
+++ b/packages/domain/src/extraction/index.ts
@@ -4,3 +4,10 @@ export {
   type ExtractedMeasurement,
   type MeasurementExtractionResult,
 } from './extractMeasurementsFromText';
+
+export {
+  extractMercariFromHtml,
+  parseMercariItemId,
+  MercariExtractionError,
+  type MercariExtraction,
+} from './mercari';

--- a/packages/domain/src/extraction/mercari.test.ts
+++ b/packages/domain/src/extraction/mercari.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { MercariExtractionError, extractMercariFromHtml, parseMercariItemId } from './mercari';
+
+const buildHtml = (metas: Record<string, string>): string => {
+  const tags = Object.entries(metas)
+    .map(([k, v]) => {
+      const attr = k.startsWith('product:') || k.startsWith('twitter:') ? 'name' : 'property';
+      return `<meta ${attr}="${k}" content="${v}"/>`;
+    })
+    .join('\n');
+  return `<!DOCTYPE html><html><head>${tags}</head><body></body></html>`;
+};
+
+describe('parseMercariItemId', () => {
+  it.each([
+    ['https://jp.mercari.com/item/m71522483801', 'm71522483801'],
+    ['https://jp.mercari.com/item/m12345678901?ref=foo', 'm12345678901'],
+    ['http://jp.mercari.com/item/m1', 'm1'],
+  ])('parses %s', (url, expected) => {
+    expect(parseMercariItemId(url)).toBe(expected);
+  });
+
+  it.each([
+    'https://www.mercari.com/jp/item/m71522483801',
+    'https://example.com/item/m71522483801',
+    'https://jp.mercari.com/search?keyword=champion',
+    'not a url',
+    '',
+  ])('rejects %s', (url) => {
+    expect(parseMercariItemId(url)).toBeNull();
+  });
+});
+
+describe('extractMercariFromHtml', () => {
+  const url = 'https://jp.mercari.com/item/m71522483801';
+
+  it('extracts name, price, image, productUrl', () => {
+    const html = buildHtml({
+      'og:title': 'Champion Reverse Weave パーカー Lサイズ by メルカリ',
+      'og:url': url,
+      'og:image': 'https://static.mercdn.net/item/detail/orig/photos/m71522483801_1.jpg?1777339695',
+      'product:price:currency': 'JPY',
+      'product:price:amount': '3800',
+    });
+    const r = extractMercariFromHtml(html, url);
+    expect(r.itemId).toBe('m71522483801');
+    expect(r.name).toBe('Champion Reverse Weave パーカー Lサイズ');
+    expect(r.priceJpy).toBe(3800);
+    expect(r.primaryImageUrl).toContain('m71522483801_1.jpg');
+    expect(r.productUrl).toBe(url);
+  });
+
+  it('strips " - メルカリ" suffix when present', () => {
+    const html = buildHtml({
+      'og:title': '90s ヴィンテージスウェット - メルカリ',
+      'og:url': url,
+    });
+    expect(extractMercariFromHtml(html, url).name).toBe('90s ヴィンテージスウェット');
+  });
+
+  it('decodes HTML entities in title', () => {
+    const html = buildHtml({
+      'og:title': 'A &amp; B Sweat &quot;rare&quot; by メルカリ',
+      'og:url': url,
+    });
+    expect(extractMercariFromHtml(html, url).name).toBe('A & B Sweat "rare"');
+  });
+
+  it('falls back to sourceUrl when og:url is missing', () => {
+    const html = buildHtml({
+      'og:title': 'Foo by メルカリ',
+    });
+    const r = extractMercariFromHtml(html, url);
+    expect(r.itemId).toBe('m71522483801');
+    expect(r.productUrl).toBe(url);
+  });
+
+  it('skips price when currency is not JPY', () => {
+    const html = buildHtml({
+      'og:title': 'Foo by メルカリ',
+      'og:url': url,
+      'product:price:currency': 'USD',
+      'product:price:amount': '120',
+    });
+    expect(extractMercariFromHtml(html, url).priceJpy).toBeUndefined();
+  });
+
+  it('skips price when amount is not finite', () => {
+    const html = buildHtml({
+      'og:title': 'Foo by メルカリ',
+      'og:url': url,
+      'product:price:currency': 'JPY',
+      'product:price:amount': 'abc',
+    });
+    expect(extractMercariFromHtml(html, url).priceJpy).toBeUndefined();
+  });
+
+  it('throws when URL is not a Mercari item page', () => {
+    const html = buildHtml({ 'og:title': 'Foo' });
+    expect(() => extractMercariFromHtml(html, 'https://example.com/foo')).toThrow(
+      MercariExtractionError,
+    );
+  });
+
+  it('throws when og:title is missing', () => {
+    const html = buildHtml({ 'og:url': url });
+    expect(() => extractMercariFromHtml(html, url)).toThrow(MercariExtractionError);
+  });
+});

--- a/packages/domain/src/extraction/mercari.ts
+++ b/packages/domain/src/extraction/mercari.ts
@@ -1,0 +1,120 @@
+/**
+ * Extract a Mercari listing's basic fields from its SSR HTML.
+ *
+ * Mercari (App Router 化済み) は商品データの大半を client から API 経由で
+ * 取得するため、SSR HTML には OGP / Open Graph product extension しか出ない。
+ * このモジュールは AI を使わずに、メタタグだけから安定して取れる範囲を返す。
+ *
+ * Available fields:
+ *  - itemId       (URL から)
+ *  - productUrl   (canonical, og:url)
+ *  - name         (og:title から末尾 " by メルカリ" 等を除去)
+ *  - primaryImageUrl (og:image)
+ *  - priceJpy     (product:price:amount, currency が JPY のときのみ)
+ *
+ * 取れないフィールド (description / seller / size / color / condition / brand /
+ * 複数枚画像) は ItemForm 側で手入力する前提。
+ */
+
+const META_RE = /<meta\s[^>]+?\/?>/gi;
+const PROPERTY_RE = /(?:property|name)=["']([^"']+)["']/i;
+const CONTENT_RE = /content=["']([^"']*)["']/i;
+const MERCARI_URL_RE = /^https?:\/\/jp\.mercari\.com(\/[^?#]*)/i;
+const ITEM_ID_RE = /\/item\/(m\d+)\b/i;
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  '#39': "'",
+};
+
+const decodeHtmlEntities = (s: string): string =>
+  s
+    .replace(/&#(\d+);/g, (_, n: string) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n: string) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&(amp|lt|gt|quot|apos|#39);/g, (m, k: string) => HTML_ENTITY_MAP[k] ?? m);
+
+const parseMetas = (html: string): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const m of html.matchAll(META_RE)) {
+    const tag = m[0];
+    const p = tag.match(PROPERTY_RE)?.[1];
+    const c = tag.match(CONTENT_RE)?.[1];
+    if (p && c !== undefined && !map.has(p.toLowerCase())) {
+      map.set(p.toLowerCase(), decodeHtmlEntities(c));
+    }
+  }
+  return map;
+};
+
+const stripMercariTitleSuffix = (title: string): string =>
+  title
+    .replace(/\s*by\s+メルカリ\s*$/u, '')
+    .replace(/\s*[-–—]\s*メルカリ\s*$/u, '')
+    .trim();
+
+const parsePriceJpy = (
+  amount: string | undefined,
+  currency: string | undefined,
+): number | undefined => {
+  if (!amount || !currency) return undefined;
+  if (currency.toUpperCase() !== 'JPY') return undefined;
+  const n = Number(amount);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.round(n);
+};
+
+/**
+ * Returns the Mercari item ID (`m\d+`) if the URL points to a jp.mercari.com
+ * item page; otherwise null. US (www.mercari.com) は別ドメインなので未対応。
+ */
+export const parseMercariItemId = (url: string): string | null => {
+  if (typeof url !== 'string') return null;
+  const hostMatch = url.match(MERCARI_URL_RE);
+  if (!hostMatch) return null;
+  const path = hostMatch[1] ?? '';
+  const idMatch = path.match(ITEM_ID_RE);
+  return idMatch?.[1] ?? null;
+};
+
+export type MercariExtraction = {
+  itemId: string;
+  productUrl: string;
+  name: string;
+  primaryImageUrl?: string;
+  priceJpy?: number;
+};
+
+export class MercariExtractionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MercariExtractionError';
+  }
+}
+
+export const extractMercariFromHtml = (html: string, sourceUrl: string): MercariExtraction => {
+  const metas = parseMetas(html);
+  const ogUrl = metas.get('og:url');
+  const itemId = parseMercariItemId(ogUrl ?? sourceUrl);
+  if (!itemId) {
+    throw new MercariExtractionError('メルカリの商品 URL ではありません');
+  }
+  const rawTitle = metas.get('og:title');
+  if (!rawTitle) {
+    throw new MercariExtractionError('og:title が見つかりませんでした');
+  }
+  const name = stripMercariTitleSuffix(rawTitle);
+  if (!name) {
+    throw new MercariExtractionError('商品名が空でした');
+  }
+  const primaryImageUrl = metas.get('og:image');
+  const priceJpy = parsePriceJpy(
+    metas.get('product:price:amount'),
+    metas.get('product:price:currency'),
+  );
+  const productUrl = ogUrl ?? `https://jp.mercari.com/item/${itemId}`;
+  return { itemId, productUrl, name, primaryImageUrl, priceJpy };
+};


### PR DESCRIPTION
## Summary
- Wishlist 追加画面の上部に「URL から取り込み」パネルを追加
- メルカリ商品 URL (`https://jp.mercari.com/item/m...`) を貼って「取り込む」を押すと、SSR HTML の OGP / Open Graph product extension から **商品名 / 現在価格 (JPY) / 画像 1 枚 / 商品 URL / sourceType=mercari / status=wishlist** を抽出し、`ItemForm` を再 mount して prefill する
- AI / LLM は未使用。`packages/domain/src/extraction/mercari.ts` に純粋関数として実装し、Vitest フィクスチャで 16 ケースをカバー

## Background
当初は `__NEXT_DATA__` から description / seller / size / 複数枚画像まで取れる前提で設計検討していたが、実 HTML を fetch して検証 (`https://jp.mercari.com/item/m71522483801`) したところ、メルカリは App Router 化済みで:

- `__NEXT_DATA__` 無し
- JSON-LD 無し
- RSC streaming chunks には商品データ本体は含まれず i18n locale 文字列のみ
- description / seller / condition / size / brand / 複数枚画像は client が API 経由で後 fetch

であることが判明。SSR で安定して取れるのは以下の meta タグだけだった:

```
og:title                = "<name> by メルカリ"
og:image                = static.mercdn.net/.../m{itemId}_1.jpg
og:url                  = canonical
product:price:amount    = "3800"
product:price:currency  = "JPY"
```

そこで本 PR では「これだけを正規表現で抽出 + ItemForm に prefill」という最小スコープに割り切った。残りのフィールドは ItemForm で手動入力する前提。

iOS Safari の User-Agent で fetch すれば Cloudflare bot fight も素朴に通る (実機検証済み)。

## Architecture

```
packages/domain/src/extraction/mercari.ts        ← 純粋関数 + 型 (No RN/Expo deps)
  ├ parseMercariItemId(url)        URL → 'm{digits}' | null
  ├ extractMercariFromHtml(html, sourceUrl) → MercariExtraction
  └ MercariExtractionError

packages/app/src/utils/fetchProductHtml.ts        UA 偽装 + timeout fetch
packages/app/src/utils/importMercariUrl.ts        fetch → extract → savePhoto → ItemFormDefaults
packages/app/app/candidate/new.tsx                URL 取り込み UI を追加
```

ファイル分離は CLAUDE.md の「domain は RN/Expo に依存しない」「screens は repository / domain を呼ぶだけ」方針に揃えた。

## Test plan
- [x] `pnpm -r test` (shared 11, domain 160 [うち mercari 16], app 43)
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm format:check`
- [x] iOS Simulator に `pnpm --filter @seam/app ios` でビルド → 実 URL を貼って prefill 確認 (名前 / 価格 / 画像 1 枚)
- [ ] Maestro E2E flow は別 PR で対応予定 (URL fetch のネットワーク前提をどう扱うか別途検討。固定 fixture HTML を流す local mock サーバ案)

## Known limits / Out of scope
- **メルカリ以外**は対象外 (今後ヤフオク / ラクマ / eBay を追加する場合は同じ extraction 構造で兄弟ファイルを足す前提)
- **売り切れ商品**で `product:price` meta が消えるケースは要追加検証
- **Cloudflare JS challenge** に当たった場合の fallback (Jina Reader 中継など) は未実装
- **複数枚画像** は `_2.jpg`, `_3.jpg` ... の規則で取れる可能性があるが本 PR では未着手