### PR TITLE
fix(app): keep focus while scrolling notes field in ItemForm

### DIFF
--- a/packages/app/src/forms/ItemForm.tsx
+++ b/packages/app/src/forms/ItemForm.tsx
@@ -343,7 +343,7 @@ export const ItemForm = ({
           paddingBottom: space.xxl + insets.bottom,
         }}
         keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
+        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
       >
         <SectionTitle>基本</SectionTitle>
 


### PR DESCRIPTION
## Summary
- #87 で `KeyboardAvoidingView` を導入してメモ欄がキーボードに隠れる問題は解消したが、`keyboardDismissMode=\"on-drag\"` のせいでスクロール開始と同時にキーボードが閉じ → TextField のフォーカスも外れて入力できなくなっていた
- iOS では `keyboardDismissMode=\"interactive\"` に切り替え。通常スクロール中はキーボードが残り、ユーザーがキーボード自体を下方向にドラッグした時だけ閉じる (Slack / iMessage と同じ標準挙動)
- Android は引き続き `on-drag` (\`interactive\` は iOS only)

## Background
#87 のレビュー時に \"スクロールしようとするとフォーカスが外れて入力できない\" という挙動を発見。`on-drag` は \"スクロールでキーボードを閉じたい\" UX を狙ったものだったが、長文メモ入力中にスクロールしたいケースの方が圧倒的に多いため `interactive` を採用する。

`packages/app/app/settings/brand-guides/[id].tsx` にも同じ `on-drag` パターンが残っているが、こちらはこの PR のスコープ外として別途対応するか判断する。

## Test plan
- [x] \`pnpm --filter @seam/app typecheck\`
- [x] \`pnpm --filter @seam/app lint\`
- [x] \`pnpm format:check\`
- [ ] iOS Simulator で Closet 詳細 → 編集 → メモ欄を tap → キーボード出現中にスクロールしてもフォーカスが維持されることを確認
- [ ] キーボード自体を下方向にドラッグすると閉じることを確認
- [ ] Wishlist (Candidate) 編集 → 出品説明 / メモ欄でも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)