### PR TITLE
fix(domain): support Mercari Shops URLs in Wishlist URL importer

### DIFF
--- a/packages/app/src/utils/importMercariUrl.ts
+++ b/packages/app/src/utils/importMercariUrl.ts
@@ -2,7 +2,7 @@ import * as FileSystem from 'expo-file-system/legacy';
 import {
   MercariExtractionError,
   extractMercariFromHtml,
-  parseMercariItemId,
+  parseMercariUrl,
 } from '@seam/domain/extraction';
 import type { ItemFormDefaults } from '../forms/ItemForm';
 import { savePhoto, type SavedPhoto } from '../photos/savePhoto';
@@ -41,7 +41,7 @@ export class ImportUrlError extends Error {
  */
 export const importMercariUrl = async (url: string): Promise<ItemFormDefaults> => {
   const trimmed = url.trim();
-  if (!parseMercariItemId(trimmed)) {
+  if (!parseMercariUrl(trimmed)) {
     throw new ImportUrlError('メルカリの商品 URL を入力してください');
   }
 

--- a/packages/domain/src/extraction/index.ts
+++ b/packages/domain/src/extraction/index.ts
@@ -7,7 +7,8 @@ export {
 
 export {
   extractMercariFromHtml,
-  parseMercariItemId,
+  parseMercariUrl,
   MercariExtractionError,
   type MercariExtraction,
+  type MercariUrlInfo,
 } from './mercari';

--- a/packages/domain/src/extraction/mercari.test.ts
+++ b/packages/domain/src/extraction/mercari.test.ts
@@ -1,37 +1,53 @@
 import { describe, expect, it } from 'vitest';
-import { MercariExtractionError, extractMercariFromHtml, parseMercariItemId } from './mercari';
+import { MercariExtractionError, extractMercariFromHtml, parseMercariUrl } from './mercari';
 
-const buildHtml = (metas: Record<string, string>): string => {
+const buildHtml = (
+  metas: Record<string, string>,
+  opts: { documentTitle?: string } = {},
+): string => {
   const tags = Object.entries(metas)
     .map(([k, v]) => {
       const attr = k.startsWith('product:') || k.startsWith('twitter:') ? 'name' : 'property';
       return `<meta ${attr}="${k}" content="${v}"/>`;
     })
     .join('\n');
-  return `<!DOCTYPE html><html><head>${tags}</head><body></body></html>`;
+  const titleTag = opts.documentTitle ? `<title>${opts.documentTitle}</title>` : '';
+  return `<!DOCTYPE html><html><head>${titleTag}${tags}</head><body></body></html>`;
 };
 
-describe('parseMercariItemId', () => {
+describe('parseMercariUrl', () => {
   it.each([
-    ['https://jp.mercari.com/item/m71522483801', 'm71522483801'],
-    ['https://jp.mercari.com/item/m12345678901?ref=foo', 'm12345678901'],
-    ['http://jp.mercari.com/item/m1', 'm1'],
+    ['https://jp.mercari.com/item/m71522483801', { kind: 'item' as const, itemId: 'm71522483801' }],
+    [
+      'https://jp.mercari.com/item/m12345678901?ref=foo',
+      { kind: 'item' as const, itemId: 'm12345678901' },
+    ],
+    ['http://jp.mercari.com/item/m1', { kind: 'item' as const, itemId: 'm1' }],
+    [
+      'https://jp.mercari.com/shops/product/2JQ9wrRXRNrZ8H5pjWetAr',
+      { kind: 'shop' as const, itemId: '2JQ9wrRXRNrZ8H5pjWetAr' },
+    ],
+    [
+      'https://jp.mercari.com/shops/product/2JQ9wrRXRNrZ8H5pjWetAr?utm_medium=share&source_location=share',
+      { kind: 'shop' as const, itemId: '2JQ9wrRXRNrZ8H5pjWetAr' },
+    ],
   ])('parses %s', (url, expected) => {
-    expect(parseMercariItemId(url)).toBe(expected);
+    expect(parseMercariUrl(url)).toEqual(expected);
   });
 
   it.each([
     'https://www.mercari.com/jp/item/m71522483801',
     'https://example.com/item/m71522483801',
     'https://jp.mercari.com/search?keyword=champion',
+    'https://jp.mercari.com/shops/abc/foo',
     'not a url',
     '',
   ])('rejects %s', (url) => {
-    expect(parseMercariItemId(url)).toBeNull();
+    expect(parseMercariUrl(url)).toBeNull();
   });
 });
 
-describe('extractMercariFromHtml', () => {
+describe('extractMercariFromHtml (item)', () => {
   const url = 'https://jp.mercari.com/item/m71522483801';
 
   it('extracts name, price, image, productUrl', () => {
@@ -43,6 +59,7 @@ describe('extractMercariFromHtml', () => {
       'product:price:amount': '3800',
     });
     const r = extractMercariFromHtml(html, url);
+    expect(r.kind).toBe('item');
     expect(r.itemId).toBe('m71522483801');
     expect(r.name).toBe('Champion Reverse Weave パーカー Lサイズ');
     expect(r.priceJpy).toBe(3800);
@@ -105,5 +122,67 @@ describe('extractMercariFromHtml', () => {
   it('throws when og:title is missing', () => {
     const html = buildHtml({ 'og:url': url });
     expect(() => extractMercariFromHtml(html, url)).toThrow(MercariExtractionError);
+  });
+});
+
+describe('extractMercariFromHtml (shop)', () => {
+  const url = 'https://jp.mercari.com/shops/product/2JQ9wrRXRNrZ8H5pjWetAr';
+
+  it('uses document <title> for name when og:title carries a shop suffix', () => {
+    const html = buildHtml(
+      {
+        'og:title': '90s DOCKERS GOLF 2タック ワイドチノ ベージュ - UNVINT/フォロワー割',
+        'og:url': url,
+        'og:image':
+          'https://assets.mercari-shops-static.com/-/large/plain/2JQ9wqyMWtUUJCknN9LzUq.jpg@jpg',
+      },
+      {
+        documentTitle: '90s DOCKERS GOLF 2タック ワイドチノ ベージュ - メルカリ',
+      },
+    );
+    const r = extractMercariFromHtml(html, url);
+    expect(r.kind).toBe('shop');
+    expect(r.itemId).toBe('2JQ9wrRXRNrZ8H5pjWetAr');
+    expect(r.name).toBe('90s DOCKERS GOLF 2タック ワイドチノ ベージュ');
+    expect(r.primaryImageUrl).toContain('2JQ9wqyMWtUUJCknN9LzUq.jpg');
+    expect(r.productUrl).toBe(url);
+  });
+
+  it('does not extract price (Shops omits product:price meta tags from SSR)', () => {
+    const html = buildHtml(
+      {
+        'og:title': 'Foo - SomeShop',
+        'og:url': url,
+      },
+      { documentTitle: 'Foo - メルカリ' },
+    );
+    expect(extractMercariFromHtml(html, url).priceJpy).toBeUndefined();
+  });
+
+  it('ignores SVG <title> elements and picks the one ending with メルカリ', () => {
+    const html = `<!DOCTYPE html><html><head>
+<title>メルカリ</title>
+<title>X</title>
+<title>Foo Bar Item - メルカリ</title>
+<meta property="og:title" content="Foo Bar Item - SomeShop"/>
+<meta property="og:url" content="${url}"/>
+</head><body></body></html>`;
+    expect(extractMercariFromHtml(html, url).name).toBe('Foo Bar Item');
+  });
+
+  it('falls back to og:title (with shop suffix kept) when no document <title> has the メルカリ suffix', () => {
+    const html = buildHtml({
+      'og:title': 'Foo Item - SomeShop',
+      'og:url': url,
+    });
+    // 完璧ではないが name=undefined よりはマシ。ユーザーが手で編集する想定。
+    expect(extractMercariFromHtml(html, url).name).toBe('Foo Item - SomeShop');
+  });
+
+  it('falls back to sourceUrl when og:url is missing', () => {
+    const html = buildHtml({ 'og:title': 'Foo - Shop' }, { documentTitle: 'Foo - メルカリ' });
+    const r = extractMercariFromHtml(html, url);
+    expect(r.itemId).toBe('2JQ9wrRXRNrZ8H5pjWetAr');
+    expect(r.productUrl).toBe(url);
   });
 });

--- a/packages/domain/src/extraction/mercari.ts
+++ b/packages/domain/src/extraction/mercari.ts
@@ -5,22 +5,29 @@
  * 取得するため、SSR HTML には OGP / Open Graph product extension しか出ない。
  * このモジュールは AI を使わずに、メタタグだけから安定して取れる範囲を返す。
  *
+ * 対応する URL 形式:
+ *  - 通常出品: `https://jp.mercari.com/item/m<digits>`
+ *  - Mercari Shops: `https://jp.mercari.com/shops/product/<base62 id>`
+ *
  * Available fields:
- *  - itemId       (URL から)
- *  - productUrl   (canonical, og:url)
- *  - name         (og:title から末尾 " by メルカリ" 等を除去)
+ *  - itemId         (URL から)
+ *  - kind           ('item' | 'shop')
+ *  - productUrl     (canonical, og:url)
+ *  - name           ('item' は og:title から、'shop' は document <title> から)
  *  - primaryImageUrl (og:image)
- *  - priceJpy     (product:price:amount, currency が JPY のときのみ)
+ *  - priceJpy       (product:price:amount; Shops は SSR に出ないので undefined)
  *
  * 取れないフィールド (description / seller / size / color / condition / brand /
- * 複数枚画像) は ItemForm 側で手入力する前提。
+ * 複数枚画像、および Shops の価格) は ItemForm 側で手入力する前提。
  */
 
 const META_RE = /<meta\s[^>]+?\/?>/gi;
 const PROPERTY_RE = /(?:property|name)=["']([^"']+)["']/i;
 const CONTENT_RE = /content=["']([^"']*)["']/i;
 const MERCARI_URL_RE = /^https?:\/\/jp\.mercari\.com(\/[^?#]*)/i;
-const ITEM_ID_RE = /\/item\/(m\d+)\b/i;
+const ITEM_PATH_RE = /^\/item\/(m\d+)\b/i;
+const SHOP_PATH_RE = /^\/shops\/product\/([A-Za-z0-9]+)\b/i;
+const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/gi;
 
 const HTML_ENTITY_MAP: Record<string, string> = {
   amp: '&',
@@ -67,25 +74,50 @@ const parsePriceJpy = (
   return Math.round(n);
 };
 
+export type MercariUrlInfo = {
+  readonly kind: 'item' | 'shop';
+  readonly itemId: string;
+};
+
 /**
- * Returns the Mercari item ID (`m\d+`) if the URL points to a jp.mercari.com
- * item page; otherwise null. US (www.mercari.com) は別ドメインなので未対応。
+ * Returns a tagged descriptor when the URL points to a jp.mercari.com item
+ * page (`/item/m<digits>`) or Mercari Shops product page
+ * (`/shops/product/<base62>`); otherwise null. US (`www.mercari.com`) は別
+ * ドメインなので未対応。
  */
-export const parseMercariItemId = (url: string): string | null => {
+export const parseMercariUrl = (url: string): MercariUrlInfo | null => {
   if (typeof url !== 'string') return null;
   const hostMatch = url.match(MERCARI_URL_RE);
   if (!hostMatch) return null;
   const path = hostMatch[1] ?? '';
-  const idMatch = path.match(ITEM_ID_RE);
-  return idMatch?.[1] ?? null;
+  const itemMatch = path.match(ITEM_PATH_RE);
+  if (itemMatch?.[1]) return { kind: 'item', itemId: itemMatch[1] };
+  const shopMatch = path.match(SHOP_PATH_RE);
+  if (shopMatch?.[1]) return { kind: 'shop', itemId: shopMatch[1] };
+  return null;
+};
+
+/**
+ * Mercari Shops の og:title は "{商品名} - {ショップ名}" 形式で、ショップ名は
+ * 任意文字列のため generic には剥がせない。document `<title>` は
+ * "{商品名} - メルカリ" 固定なのでこちらを優先する。SVG 等の `<title>` 混入を
+ * 避けるため "メルカリ" suffix を持つものを選ぶ。
+ */
+const findShopDocumentTitle = (html: string): string | undefined => {
+  for (const m of html.matchAll(TITLE_RE)) {
+    const txt = decodeHtmlEntities((m[1] ?? '').trim());
+    if (/[-–—]\s*メルカリ\s*$/u.test(txt)) return txt;
+  }
+  return undefined;
 };
 
 export type MercariExtraction = {
-  itemId: string;
-  productUrl: string;
-  name: string;
-  primaryImageUrl?: string;
-  priceJpy?: number;
+  readonly kind: 'item' | 'shop';
+  readonly itemId: string;
+  readonly productUrl: string;
+  readonly name: string;
+  readonly primaryImageUrl?: string;
+  readonly priceJpy?: number;
 };
 
 export class MercariExtractionError extends Error {
@@ -98,23 +130,41 @@ export class MercariExtractionError extends Error {
 export const extractMercariFromHtml = (html: string, sourceUrl: string): MercariExtraction => {
   const metas = parseMetas(html);
   const ogUrl = metas.get('og:url');
-  const itemId = parseMercariItemId(ogUrl ?? sourceUrl);
-  if (!itemId) {
+  const info = parseMercariUrl(ogUrl ?? sourceUrl);
+  if (!info) {
     throw new MercariExtractionError('メルカリの商品 URL ではありません');
   }
-  const rawTitle = metas.get('og:title');
+
+  const rawTitle =
+    info.kind === 'shop'
+      ? (findShopDocumentTitle(html) ?? metas.get('og:title'))
+      : metas.get('og:title');
   if (!rawTitle) {
-    throw new MercariExtractionError('og:title が見つかりませんでした');
+    throw new MercariExtractionError('商品名が見つかりませんでした');
   }
   const name = stripMercariTitleSuffix(rawTitle);
   if (!name) {
     throw new MercariExtractionError('商品名が空でした');
   }
+
   const primaryImageUrl = metas.get('og:image');
-  const priceJpy = parsePriceJpy(
-    metas.get('product:price:amount'),
-    metas.get('product:price:currency'),
-  );
-  const productUrl = ogUrl ?? `https://jp.mercari.com/item/${itemId}`;
-  return { itemId, productUrl, name, primaryImageUrl, priceJpy };
+  const priceJpy =
+    info.kind === 'item'
+      ? parsePriceJpy(metas.get('product:price:amount'), metas.get('product:price:currency'))
+      : undefined;
+
+  const fallbackUrl =
+    info.kind === 'item'
+      ? `https://jp.mercari.com/item/${info.itemId}`
+      : `https://jp.mercari.com/shops/product/${info.itemId}`;
+  const productUrl = ogUrl ?? fallbackUrl;
+
+  return {
+    kind: info.kind,
+    itemId: info.itemId,
+    productUrl,
+    name,
+    primaryImageUrl,
+    priceJpy,
+  };
 };


### PR DESCRIPTION
## Summary
- メルカリ Shops の商品 URL (`https://jp.mercari.com/shops/product/<id>`) で URL 取り込みが失敗していた問題を修正
- 既存の URL パーサ \`parseMercariItemId\` (\`/item/m\d+\` のみマッチ) を \`parseMercariUrl\` に置き換え、\`{ kind: 'item' | 'shop'; itemId }\` を返すように
- \`extractMercariFromHtml\` を kind 別に分岐:
  - **item** (従来): \`og:title\` から商品名、\`product:price:*\` から価格抽出 (変更なし)
  - **shop**: document \`<title>\` (\`{商品名} - メルカリ\` 固定) から商品名を取得、価格は SSR HTML に出ないためスキップ

## Background
報告 URL: https://jp.mercari.com/shops/product/2JQ9wrRXRNrZ8H5pjWetAr

メルカリ Shops の SSR HTML を実機検証した結果、以下 2 点で通常出品と差があり既存ロジックでは扱えなかった:

1. **URL 形式**: \`/shops/product/<base62 id>\` (例: \`2JQ9wrRXRNrZ8H5pjWetAr\`)。既存正規表現 \`\/item\/(m\d+)\` ではマッチせず、import 時点で \"メルカリの商品 URL を入力してください\" エラー
2. **\`og:title\` の suffix**: 通常出品は \" by メルカリ\" / \" - メルカリ\" 固定だが、Shops は \" - {ショップ名}\" (任意文字列)。既存の strip 処理ではショップ名が商品名に残る
3. **価格 meta tag 不在**: Shops の SSR HTML には \`product:price:amount\` / \`product:price:currency\` が出ない (client API 経由で render される) → 自動抽出不可、ユーザーが手入力する

document \`<title>\` は通常出品も Shops も \`{商品名} - メルカリ\` 形式なので、Shops ではこちらを優先する。SVG 内の \`<title>\` を誤って拾わないよう \"- メルカリ\" suffix を持つものに限定。

## Test plan
- [x] \`pnpm --filter @seam/domain test\` (16 files / 168 tests, 新規 6 ケース含む)
- [x] \`pnpm -r typecheck\`
- [x] \`pnpm --filter @seam/app lint\`
- [x] \`pnpm format:check\`
- [ ] iOS Simulator で Wishlist 新規追加 → 報告 URL を貼り付け → 名前・画像が自動入力され、価格欄は空で残ることを確認
- [ ] 通常出品 (\`/item/m...\`) URL の取り込みが回帰していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)