### PR TITLE
docs: trim CLAUDE.md per best practices, extract E2E details into a skill

### DIFF
--- a/.claude/skills/e2e-maestro/SKILL.md
+++ b/.claude/skills/e2e-maestro/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: e2e-maestro
+description: Seam の Maestro E2E テストの実行・作成・デバッグ手順。新機能や UI を追加/変更したとき (testID の付与、flow の追加、リグレッション確認)、Maestro flow が落ちたときの原因切り分け、`.maestro/` 配下の編集時に使う。「E2E」「Maestro」「flow が落ちる」「testID」「リグレッション確認」等で起動。
+user-invocable: true
+---
+
+# Maestro E2E skill
+
+ローカル開発と GitHub Actions (`macos-26` runner) の両方で動く。**両方で回せる
+ようにすることが第一級要件** — Linux CI で simulator が動かない以上、ローカル
+or macos runner 上の Maestro が唯一の自動回帰検出経路。
+
+- ローカル: 開発中の高速フィードバック (`pnpm test:e2e[:smoke|:core|:regression]`)
+- CI: `.github/workflows/e2e-ios.yml` が `workflow_dispatch` または PR への
+  `e2e` ラベル付与でのみ起動。`macos-26` + Xcode 26.2 で `expo prebuild` →
+  `xcodebuild build` (Debug / iphonesimulator) → simulator boot → Metro 起動
+  → `maestro test --exclude-tags=reset .maestro/` を実行。失敗時は screen
+  recording (mp4)、JUnit report、Metro log、`~/.maestro` debug dir、xcodebuild
+  log を artifact として upload する。
+- PUBLIC repo のため macos runner も**完全無料**。pnpm store / CocoaPods /
+  DerivedData / `~/.maestro` をキャッシュして warm run は 13〜15 分目安。
+
+## 前提条件
+
+- Java 17 (`brew install openjdk@17`)。npm scripts が `JAVA_HOME` をインラインで
+  注入するので、シェルでの export は不要。
+- Maestro CLI 2.5+ (`brew install mobile-dev-inc/tap/maestro`)。
+- Xcode + iOS Simulator が起動済みで、`pnpm --filter @seam/app ios` を一度実行して
+  Seam がインストールされていること。
+- コード変更を dev build に反映するため Metro が起動していること
+  (`pnpm --filter @seam/app start`。`pnpm ios` を使えば自動で起動する)。
+
+`pnpm test:e2e:precheck` が上記すべてを検証して不足時の対処を表示する。
+`test:e2e*` スクリプトはすべて暗黙的にこれを実行する。
+
+## スクリプト
+
+```sh
+pnpm test:e2e              # reset を除く全 flow (デフォルト)
+pnpm test:e2e:smoke        # tag: smoke — 起動 + 全タブ巡回 (~5s)
+pnpm test:e2e:core         # tag: core  — P0 ライフサイクル + Buy 決定 (~2 min)
+pnpm test:e2e:regression   # tag: regression — P0+P1+P2 (~5 min)
+pnpm test:e2e:reset        # CUJ-026: UI 経由でデータ全削除 (opt-in、デフォルト除外)
+pnpm test:e2e:hierarchy    # 現在の Simulator UI ツリーを stdout に dump
+```
+
+## flow の配置
+
+`.maestro/` の命名規則:
+
+- `00_smoke.yaml` — 起動 + 全タブ可視
+- `05_reset.yaml` — UI 経由 DB wipe (`tag: reset`)
+- `10_*` — Item ライフサイクル (CRUD, wear log)
+- `15_*` — Item 売却フロー
+- `20_*` — Candidate ライフサイクル (CRUD)
+- `25_*` / `26_*` — 決定 (Buy / Watch / Skip / Lost)
+- `30_*` — 横断的 read-only 画面 (Compare / Stats)
+- `40_*` — Settings サブ画面 (個人ルール / ブランドガイド)
+- `50_*` — Closet フィルタ (P2、視覚確認補足、regression 外)
+
+`.maestro/_helpers/` 配下のサブフローは `_` 接頭辞で自動探索の対象外。
+`runFlow: '<helper>.yaml'` で呼び、`env:` でパラメータを渡す。
+
+## Selector policy
+
+1. **`id:` (testID) 最優先**。タブ / FAB / フォーム / Picker / Modal アクション /
+   業務動詞ボタン / 動的リスト行はすべて testID を必須とし、文言変更で flow が
+   黙って通る/落ちる事故を防ぐ。
+2. testID は `packages/app/src/utils/testIds.ts` に集約。flow ファイル内の
+   `id: "..."` 文字列は **手書きでこの定数と同期**させる (Maestro 側に import
+   機構が無い)。
+3. `text:` は assert 専用 — Stack header の英字 title (`Closet` / `Wishlist`)
+   や日本語固定見出しに使う。tap には基本使わない。
+4. assertVisible で部分一致したい場合は明示的に regex 形式 (`'.*${name}.*'`)
+   を書く。Maestro v2.5 の `text:` は accessibilityText に対して期待どおり
+   substring match しないことがある。
+
+## DB state policy
+
+- flow 間で DB を自動 reset しない (累積を許容)。各 flow は固有のフィクスチャ
+  名 (`E_Item_Lifecycle`, `E_Buy_Decision` など) を使うので衝突しない。
+- 完全クリーンが欲しいときだけ `pnpm test:e2e:reset` で UI 経由 wipe を行う。
+  `tag: reset` で default 実行から除外している。
+
+## E2E から除外している領域
+
+- **JSON / CSV エクスポート** — iOS の Share Sheet を Maestro で操作できない。
+- **JSON インポート** — `expo-document-picker` のシステムダイアログが操作不能。
+- **OS 通知パーミッション** — Simulator 上の `expo-notifications` 動作が不安定。
+- **写真追加** — Photo Library / Camera のシステム UI 経由は省略。
+
+これらは repository / domain の unit test (vitest) でカバーする。
+
+## 新画面・新コンポーネント追加時のワークフロー
+
+新機能 / UI 変更時は **対応する testID と flow を同 PR に含める**。
+
+1. 機能を実装。
+2. 関連 testID を `packages/app/src/utils/testIds.ts` に追加 (命名:
+   `scope:action:dynamicId`、kebab-case)。
+3. UI 要素に testID prop を渡す:
+   - Button / TextField / Picker / Chip / ItemCard / SegmentedControl /
+     PhotoPicker / EmptyState / StatCard はすべて `testID?: string` を受け取る
+   - Modal の root には固定 testID (`modal:wear-log` 等) を直書き
+   - Picker の trigger 側に `picker:foo` を渡すと、option 行は自動で
+     `option:foo:value` に派生
+4. 既存 flow に組み込めるなら organic に追加。新 CUJ なら新 flow を
+   `<NN>_*.yaml` で作る (NN は既存範囲 10/20/30/40/50 の空き番)。
+5. 必要に応じて `.maestro/_helpers/*.yaml` に共通化。
+6. plan の CUJ 表 (`/Users/shingosato/.claude/plans/cuj-e2e-test-parallel-wreath.md`)
+   を更新。
+
+## 変更規模ごとの実行範囲
+
+| 変更の規模 | 走らせる flow |
+|---|---|
+| typo / コメント / ドキュメント | (なし or `pnpm test:e2e:smoke`) |
+| 新機能 / UI 変更 / ItemForm 修正 | `pnpm test:e2e:smoke` → `:core` → `:regression` |
+| リファクタ / 依存更新 | `pnpm test:e2e:regression` 必須 |
+| Maestro flow 自体の変更 | 個別 flow を `maestro test .maestro/<name>.yaml` |
+
+## ガッチャ早見表
+
+- **destructive な Alert button のラベルは `削除する` に統一**。背景に `削除`
+  テキスト (Pressable) があると Maestro が後ろを tap してしまう。
+- **ItemCard 等のリスト行に `accessibilityLabel` を付けない**。子の `<Text>`
+  が accessibility tree から消えて assertVisible が effective に動かなくなる。
+- **ItemForm の submit ボタンは ScrollView 末尾**。`tapOn id:'btn:submit'` の
+  前に必ず `scrollUntilVisible visibilityPercentage:50` を入れる。
+- **Stack push 後は tab bar が見えない**。`goto_settings` 等を再呼び出しする
+  前に `_helpers/launch.yaml` で cold restart する。
+- **Decision/Sale/WearLog Modal 内では `point: '50%, 18%'` を絶対に tap しない**。
+  Modal 背景 (backdrop) を tap してしまい cancel になる。
+
+## 失敗時のセルフデバッグ手順
+
+flow が落ちたら以下を順に試す:
+
+```sh
+# 1. 最新の失敗成果物
+ls -t ~/.maestro/tests | head -1
+
+# 2. screenshot-❌-*.png を Read tool で確認 (実際の画面状態)
+
+# 3. UI tree を dump して selector の真の id/text/accessibilityText を確認
+pnpm test:e2e:hierarchy > /tmp/h.txt
+grep -nE '"(text|accessibilityText)"' /tmp/h.txt | grep -v '""'
+
+# 4. 修正方針:
+#    - testID が見つからない → アプリ側で testID 付与漏れ → testIds.ts 拡張
+#    - text 検索が失敗 → accessibilityText の完全形を確認 → '.*X.*' regex
+#    - submit が見えない → scrollUntilVisible (visibilityPercentage: 50)
+#    - 入力後 modal が誤 open → tapOn point: '50%, 18%' で blur (※ Modal 内では
+#      backdrop tap になるので注意)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,329 +1,136 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Claude Code が毎セッション読み込む常時ルール。ここには「コードを読めば分かること」
+は書かない。たまにしか要らない手順は `.claude/skills/` に置く。
 
-## Project
+## プロジェクト
 
-Seam is a personal iOS app (Expo + React Native) for deciding whether to buy
-vintage clothing by comparing candidate items against owned items by
-measurement, price, condition, and duplication risk. Local-first; no auth; no
-App Store distribution. Full requirements live in `plan/initial-plan.md`.
+Seam は古着の購入判断を支援する個人用 iOS アプリ (Expo + React Native)。候補品を
+手持ち品と採寸 / 価格 / コンディション / 重複リスクで比較する。ローカル完結・認証
+なし・App Store 配布なし。要件の全体像は `plan/initial-plan.md`。
 
-## Monorepo layout
+## 構成
 
-pnpm workspaces. Three packages, all `private`:
+pnpm workspaces、3 パッケージすべて `private`。
 
-- `packages/app/` — Expo SDK 55 iOS app. Expo Router (`app/` dir), expo-sqlite,
-  Drizzle ORM, Zustand, react-hook-form, expo-notifications.
-- `packages/domain/` — pure-TS domain logic (`type: "module"`). No RN / Expo
-  imports. Subpath exports: `compare`, `scoring`, `extraction`, `pricing`,
-  `wear`, `units`, `rules`. Tested with Vitest.
-- `packages/shared/` — Zod schemas, TS types, and constants (Japanese
-  display labels like `CATEGORY_LABEL` live as `*_LABEL` exports under
-  `constants/`). Imported by both `app` and `domain`.
+| パッケージ | 中身 |
+|---|---|
+| `packages/app` | Expo SDK 55 の iOS アプリ。Expo Router / expo-sqlite / Drizzle ORM / react-hook-form |
+| `packages/domain` | 純 TS のドメインロジック (`type: "module"`)。subpath exports: `compare` `scoring` `extraction` `pricing` `wear` `units` `rules` |
+| `packages/shared` | Zod スキーマ・型・定数 (`schemas` / `types` / `constants`)。`app` と `domain` の両方から参照される |
 
-Workspace path aliases (resolved by `tsconfig` paths and Metro):
+パスエイリアス (tsconfig paths と Metro の両方で解決): `@seam/shared`,
+`@seam/shared/*`, `@seam/domain`, `@seam/domain/*`, `@/*` → `packages/app/src/*`
+(app のみ)。
 
-- `@seam/shared`, `@seam/shared/*`
-- `@seam/domain`, `@seam/domain/*`
-- `@/*` → `packages/app/src/*` (app only)
+**`@seam/domain` / `@seam/shared` はソース (`./src/index.ts`) を直接解決する。**
+ビルド済み成果物を挟んでいないので、`dist` ベースの build step を足すなら package
+の `exports` も同時に直すこと。
 
-`@seam/domain` and `@seam/shared` resolve directly to source (`./src/index.ts`)
-— they are not built before consumption. Don't add a `dist`-based build step
-unless you also update the package `exports`.
+## コマンド
 
-## Commands
-
-Run from the repo root unless noted. Cross-package scripts use `pnpm -r`.
+リポジトリルートで実行する。横断スクリプトは `pnpm -r`。
 
 ```sh
-pnpm install              # install all workspaces
-pnpm typecheck            # pnpm -r typecheck (each package: tsc --noEmit)
-pnpm test                 # pnpm -r test (vitest run in each package)
-pnpm lint                 # pnpm -r lint (only @seam/app has eslint)
-pnpm build                # pnpm -r build (no-op today; no package implements build)
-pnpm format               # biome format --write . (config: biome.json)
-pnpm format:check         # biome format . — used by CI
+pnpm typecheck            # 各パッケージ tsc --noEmit
+pnpm test                 # 各パッケージ vitest run
+pnpm lint                 # eslint (@seam/app のみ)
+pnpm format               # biome format --write .
+pnpm format:check         # CI と同じ整形チェック
 ```
 
-Biome is configured for formatting only (`linter.enabled: false`); ESLint is
-still the linter for `@seam/app`. Biome's `files.includes` excludes
-`packages/app/src/db/migrations/**`, native `ios/`/`android/` dirs, and build
-output.
-
-Single-package and single-test:
+単一パッケージ / 単一テスト:
 
 ```sh
 pnpm --filter @seam/domain test
 pnpm --filter @seam/domain test:watch
-pnpm --filter @seam/domain test:coverage
-pnpm --filter @seam/app typecheck
 pnpm --filter @seam/domain vitest run src/scoring/calculateSizeScore.test.ts
 pnpm --filter @seam/domain vitest run -t "calculateSizeScore"
+pnpm --filter @seam/app typecheck
 ```
 
-App-only (must `cd packages/app` for Expo CLI):
+Expo CLI 系は `packages/app` に `cd` してから:
 
 ```sh
-cd packages/app
-pnpm ios                  # build & run on iOS simulator (requires Xcode)
-pnpm start                # Metro + QR for Expo Go (limited features)
-pnpm prebuild             # regenerate native ios/ project
-pnpm drizzle:generate     # emit src/db/migrations/*.sql + migrations.js
-pnpm drizzle:check        # validate migration history
+pnpm ios                  # iOS Simulator でビルド & 起動 (要 Xcode)
+pnpm start                # Metro 起動
+pnpm prebuild             # native ios/ を再生成 (scripts/prebuild.mjs)
+pnpm drizzle:generate     # src/db/migrations/*.sql + migrations.js を生成
+pnpm drizzle:check        # マイグレーション履歴の検証
 ```
 
-E2E (Maestro): see the **E2E (Maestro)** section below. ローカル
-(`pnpm test:e2e` 等) と GitHub Actions (`.github/workflows/e2e-ios.yml`,
-macos-26 runner) の両方で実行可能。
+Biome は**整形専用** (`linter.enabled: false`)。lint は引き続き ESLint
+(`@seam/app` のみ)。`pnpm build` は全パッケージ未実装の no-op。
 
-CI (`.github/workflows/test.yml`) runs, in order, `pnpm format:check`,
-`pnpm -r lint`, `pnpm -r typecheck`, `pnpm -r test`, then a Metro bundle build
-(`expo export --platform ios`) on every push / PR to `main`. Maestro はコスト
-管理のため `e2e-ios.yml` 側に分離し、`workflow_dispatch` または PR への `e2e`
-ラベル付与でのみ実行する (PUBLIC repo なので macos runner も無料)。
+E2E (Maestro) は `.claude/skills/e2e-maestro/` を参照。**新機能 / UI 変更を入れる
+ときは、対応する testID と flow を同じ PR に含めること。** Linux CI では
+simulator が動かないため、ローカル or macos runner の Maestro が唯一の自動回帰
+検出経路になっている。
 
-`.github/workflows/release.yml` is a separate workflow that triggers on `v*`
-tags (or `workflow_dispatch`). On macOS it runs `expo prebuild`, strips the
-push entitlement, and produces an **unsigned** IPA via `xcodebuild archive`
-(`CODE_SIGNING_ALLOWED=NO`); the IPA is attached to a GitHub Release, and
-`.github/scripts/update-source.mjs` rewrites `docs/source.json` (the
-AltStore-style source manifest served from GitHub Pages). The tag version
-must match `packages/app/app.json`'s `expo.version`, otherwise the workflow
-fails fast.
+## CI と git hooks
 
-## Database & migrations
+- lefthook (`lefthook.yml`、`pnpm install` の `prepare` で導入)。
+  **pre-commit** = staged ファイルの Biome 整形のみ。
+  **pre-push** = `format:check` + `lint` + `typecheck` + `test` のフルゲート。
+  push が遅いのは仕様。
+- `.github/workflows/test.yml` — main への push / PR で
+  `expo install --check` (Expo SDK peer 整合) → format:check → lint → typecheck
+  → test → Metro バンドル (`expo export --platform ios`)。
+- `.github/workflows/e2e-ios.yml` — `workflow_dispatch` または PR への `e2e`
+  ラベル付与でのみ起動 (macos runner のコスト管理)。
+- `.github/workflows/ios-build-check.yml` — `packages/app/package.json` /
+  `app.json` / `pnpm-lock.yaml` 等の変更時のみ native ビルドを検証。
+- リリース (`v*` タグ → 未署名 IPA → GitHub Release → `docs/source.json` 更新)
+  は `.claude/skills/release/` の手順で行う。**タグのバージョンは
+  `packages/app/app.json` の `expo.version` と一致必須**、不一致なら workflow が
+  即失敗する。
 
-- Drizzle schema: `packages/app/src/db/schema.ts` (single source of truth for
-  every table). DB client: `packages/app/src/db/client.ts` (`db`, `sqlite`,
-  `schema` re-export). Drizzle config: `packages/app/drizzle.config.ts`
-  (`dialect: 'sqlite'`, `driver: 'expo'`).
-- Migrations live in `packages/app/src/db/migrations/`. **Always run
-  `pnpm drizzle:generate` after editing `schema.ts`** — it produces both the
-  `.sql` files and the `migrations.js` index that the app imports.
-- Migrations are applied at app start via `useDbMigrations()`
-  (`packages/app/src/db/migrate.ts`) called in `app/_layout.tsx`. The
-  `.sql` files are inlined into the JS bundle by the
-  `babel-plugin-inline-import` plugin configured in `babel.config.js` — this
-  is why migrations work in production builds without filesystem access. Do
-  not remove that plugin.
-- Local SQLite files (`*.db`, `*.sqlite`) are gitignored.
+## DB とマイグレーション
 
-## Domain layer rules
+- スキーマの単一情報源は `packages/app/src/db/schema.ts`。DB クライアントは
+  `src/db/client.ts` (`db`, `sqlite`, `schema`)。
+- **`schema.ts` を編集したら必ず `pnpm drizzle:generate` を実行する。**
+  `.sql` とアプリが import する `migrations.js` インデックスの両方を生成する。
+- マイグレーションは起動時に `useDbMigrations()` (`src/db/migrate.ts`、
+  `app/_layout.tsx` から呼ぶ) で適用。`.sql` は `babel.config.js` の
+  `babel-plugin-inline-import` で JS バンドルにインライン化される
+  (本番ビルドでファイルシステムなしに動く理由)。**このプラグインを外さないこと。**
+- ローカルの SQLite ファイル (`*.db`, `*.sqlite`) は gitignore 済み。
 
-- `packages/domain/` must stay free of React Native, Expo, and SQLite
-  imports. It is pure TS and is consumed by both the app and unit tests.
-- Per `plan/initial-plan.md` and `tsconfig.base.json`: TypeScript strict mode
-  is enforced (`noImplicitAny`, `strictNullChecks`, `noUncheckedIndexedAccess`,
-  `noImplicitReturns`). Do not introduce `any`.
-- All scoring / comparison / extraction / pricing logic must be pure
-  functions. UI/repository code consumes domain functions; it does not
-  re-implement them. New scoring or comparison logic belongs under
-  `packages/domain/src/<area>/` with a co-located `*.test.ts`.
+## レイヤー境界
 
-## Repository layer
+- **`packages/domain` に React Native / Expo / SQLite を import しない。** 純 TS
+  のまま保ち、アプリと unit test の両方から使う。
+- スコアリング / 比較 / 抽出 / 価格算出はすべて純関数。UI やリポジトリ層はドメイン
+  関数を**呼ぶ**だけで再実装しない。新しいロジックは
+  `packages/domain/src/<area>/` に `*.test.ts` を併置して追加する。
+- リポジトリはテーブル 1 つにつき 1 ファイル (`packages/app/src/repositories/`、
+  `index.ts` から re-export)。**複数テーブルをまたぐ操作 (measurements + photos +
+  tags 付きの item 作成、candidate → owned 昇格、売却 / 売却取消) は
+  `repositories/itemFlow.ts` を入口にする。** 画面側で複数リポジトリを都度合成しない。
+- 画面はリポジトリとドメイン関数を呼ぶ。**コンポーネント内から生の `db` クエリを
+  書かない。**
 
-`packages/app/src/repositories/` — one repository per table, all re-exported
-from `repositories/index.ts`. Cross-table workflows (creating an item with
-measurements + photos + tags + candidate info; converting candidate → owned;
-sold/unsold transitions) live in `repositories/itemFlow.ts` and are the
-preferred entry points from screens / forms — don't compose multiple
-repositories ad hoc in UI code.
+## UI
 
-## Routing & UI
+- Expo Router のファイルベースルーティング (`packages/app/app/`)、typed routes
+  有効 (`app.json` → `experiments.typedRoutes`)。
+- 共通 UI は `packages/app/src/components/` に置き `components/index.ts` から
+  re-export。スタイルは `src/theme/` のトークン (`font`, `space`,
+  `useThemeColors` 等) を使い、値を直書きしない。
+- フォームは react-hook-form + Zod resolver。手本は `src/forms/ItemForm.tsx`。
+- 写真は `src/photos/savePhoto.ts` でアプリの document directory にコピーし、
+  **SQLite には相対パス (`photos.relative_path`) だけを保存する。** 絶対 URI は
+  再インストールや iOS のコンテナ名変更で壊れる。
 
-- Expo Router with file-based routes under `packages/app/app/`:
-  - `(tabs)/` — bottom tab screens (Home, Closet, Wishlist, Compare, Stats,
-    Settings).
-  - `item/[id].tsx`, `item/new.tsx` — owned-item CRUD screens.
-  - `candidate/[id].tsx`, `candidate/new.tsx` — candidate CRUD screens.
-  - `settings/` — sub-screens (measurement-rules, brand-guides, data-reset).
-- Typed routes are enabled (`app.json` → `experiments.typedRoutes`).
-- Reusable UI lives in `packages/app/src/components/` and is re-exported from
-  `components/index.ts`. Theme tokens (`font`, `space`, `useThemeColors`,
-  etc.) come from `packages/app/src/theme/`. Prefer these over hard-coded
-  styles.
-- Forms use react-hook-form + Zod resolvers; the canonical example is
-  `src/forms/ItemForm.tsx`.
+## 規約
 
-## Notifications, photos, backup
-
-- `src/notifications/` wraps `expo-notifications`. Foreground handler is
-  configured once at module load from `app/_layout.tsx`
-  (`configureNotificationHandler()`). Reminders are persisted in the
-  `reminders` table so the configured state can be restored.
-- `src/photos/savePhoto.ts` copies picked images into the app's
-  document directory and stores only the relative path in SQLite (the
-  `photos.relative_path` column). Don't store absolute URIs — they break
-  across app reinstalls and iOS container renames.
-- `src/backup/` — JSON export/import (Zod-validated, supports `merge` and
-  `replace` modes), CSV export of `items`, and full data reset. The
-  data-reset path also wipes on-disk photo blobs and the last-export tracker.
-
-## E2E (Maestro)
-
-ローカル開発と GitHub Actions (`macos-26` runner) の両方で動く。**両方で回せる
-ようにすることが第一級要件** — Linux CI で simulator が動かない以上、ローカル
-or macos runner 上の Maestro が唯一の自動回帰検出経路。
-
-- ローカル: 開発中の高速フィードバック (`pnpm test:e2e[:smoke|:core|:regression]`)
-- CI: `.github/workflows/e2e-ios.yml` が `workflow_dispatch` または PR への
-  `e2e` ラベル付与でのみ起動。`macos-26` + Xcode 26.2 で `expo prebuild` →
-  `xcodebuild build` (Debug / iphonesimulator) → simulator boot → Metro 起動
-  → `maestro test --exclude-tags=reset .maestro/` を実行。失敗時は screen
-  recording (mp4)、JUnit report、Metro log、`~/.maestro` debug dir、xcodebuild
-  log を artifact として upload する。
-- PUBLIC repo のため macos runner も**完全無料**。pnpm store / CocoaPods /
-  DerivedData / `~/.maestro` をキャッシュして warm run は 13〜15 分目安。
-
-### Prerequisites
-
-- Java 17 (`brew install openjdk@17`). The npm scripts inject `JAVA_HOME`
-  inline, so a one-off shell export isn't needed.
-- Maestro CLI 2.5+ (`brew install mobile-dev-inc/tap/maestro`).
-- Xcode + iOS Simulator booted, and `pnpm --filter @seam/app ios` once to
-  install Seam onto the booted device.
-- Metro running so the dev build picks up code changes (`pnpm --filter @seam/app start`
-  if not already up — `pnpm ios` starts it for you).
-
-The `pnpm test:e2e:precheck` script verifies all of the above and prints
-remediation hints; every `test:e2e*` script runs it implicitly.
-
-### Scripts
-
-```sh
-pnpm test:e2e              # all flows except `reset` (default loop)
-pnpm test:e2e:smoke        # tag: smoke — boots app + visits every tab (~5s)
-pnpm test:e2e:core         # tag: core  — P0 lifecycles + Buy decision (~2 min)
-pnpm test:e2e:regression   # tag: regression — P0+P1+P2 (~5 min)
-pnpm test:e2e:reset        # CUJ-026: UI 経由でデータ全削除 (opt-in、デフォルトから除外)
-pnpm test:e2e:hierarchy    # 現在の Simulator UI ツリーを stdout に dump
-```
-
-### Flow layout
-
-`.maestro/` の命名規則:
-
-- `00_smoke.yaml` — 起動 + 全タブ可視
-- `05_reset.yaml` — UI 経由 DB wipe (`tag: reset`)
-- `10_*` — Item ライフサイクル (CRUD, wear log)
-- `15_*` — Item 売却フロー
-- `20_*` — Candidate ライフサイクル (CRUD)
-- `25_*` / `26_*` — 決定 (Buy / Watch / Skip / Lost)
-- `30_*` — 横断的 read-only 画面 (Compare / Stats)
-- `40_*` — Settings サブ画面 (個人ルール / ブランドガイド)
-- `50_*` — Closet フィルタ (P2、視覚確認補足、regression 外)
-
-`.maestro/_helpers/` 配下のサブフローは `_` 接頭辞で自動探索の対象外。
-`runFlow: '<helper>.yaml'` で呼び、`env:` でパラメータを渡す。
-
-### Selector policy
-
-1. **`id:` (testID) 最優先**。タブ / FAB / フォーム / Picker / Modal アクション /
-   業務動詞ボタン / 動的リスト行はすべて testID を必須とし、文言変更で flow が
-   黙って通る/落ちる事故を防ぐ。
-2. testID は `packages/app/src/utils/testIds.ts` に集約。flow ファイル内の
-   `id: "..."` 文字列は **手書きでこの定数と同期**させる (Maestro 側に import
-   機構が無い)。
-3. `text:` は assert 専用 — Stack header の英字 title (`Closet` / `Wishlist`)
-   や日本語固定見出しに使う。tap には基本使わない。
-4. assertVisible で 部分一致したい場合は明示的に regex 形式 (`'.*${name}.*'`)
-   を書く。Maestro v2.5 の `text:` は accessibilityText に対して期待どおり
-   substring match しないことがある。
-
-### DB state policy
-
-- flow 間で DB を自動 reset しない (累積を許容)。各 flow は固有のフィクスチャ
-  名 (`E_Item_Lifecycle`, `E_Buy_Decision` など) を使うので衝突しない。
-- 完全クリーンが欲しいときだけ `pnpm test:e2e:reset` で UI 経由 wipe を行う。
-  `tag: reset` で default 実行から除外している。
-
-### Known constraints (E2E から除外している領域)
-
-- **JSON / CSV エクスポート** — iOS の Share Sheet を Maestro で操作できない。
-- **JSON インポート** — `expo-document-picker` のシステムダイアログが操作不能。
-- **OS 通知パーミッション** — Simulator 上の `expo-notifications` 動作が不安定。
-- **写真追加** — Photo Library / Camera のシステム UI 経由は省略。
-
-これらは repository / domain の unit test (vitest) でカバーする。
-
-### Self-debug recipe
-
-flow が落ちたら以下を順に試す:
-
-```sh
-# 1. 最新の失敗成果物
-ls -t ~/.maestro/tests | head -1
-
-# 2. screenshot-❌-*.png を Read tool で確認 (実際の画面状態)
-
-# 3. UI tree を dump して selector の真の id/text/accessibilityText を確認
-pnpm test:e2e:hierarchy > /tmp/h.txt
-grep -nE '"(text|accessibilityText)"' /tmp/h.txt | grep -v '""'
-
-# 4. 修正方針:
-#    - testID が見つからない → アプリ側で testID 付与漏れ → testIds.ts 拡張
-#    - text 検索が失敗 → accessibilityText の完全形を確認 → '.*X.*' regex
-#    - submit が見えない → scrollUntilVisible (visibilityPercentage: 50)
-#    - 入力後 modal が誤 open → tapOn point: '50%, 18%' で blur (※ Modal 内では
-#      backdrop tap になるので注意)
-```
-
-## E2E 開発ワークフロー (Claude 運用)
-
-新機能 / UI 変更時は **対応する testID と flow を同 PR に含める**。これは
-Linux CI で simulator が動かない以上、Claude のローカル E2E 実行が唯一の自動
-回帰検出経路だから。
-
-### 新画面・新コンポーネント追加時
-
-1. 機能を実装。
-2. 関連 testID を `packages/app/src/utils/testIds.ts` に追加 (命名:
-   `scope:action:dynamicId`、kebab-case)。
-3. UI 要素に testID prop を渡す:
-   - Button / TextField / Picker / Chip / ItemCard / SegmentedControl /
-     PhotoPicker / EmptyState / StatCard はすべて `testID?: string` を受け取る
-   - Modal の root には固定 testID (`modal:wear-log` 等) を直書き
-   - Picker の trigger 側に `picker:foo` を渡すと、option 行は自動で
-     `option:foo:value` に派生
-4. 既存 flow に組み込めるなら organic に追加。新 CUJ なら新 flow を
-   `<NN>_*.yaml` で作る (NN は既存範囲 10/20/30/40/50 の空き番)。
-5. 必要に応じて `.maestro/_helpers/*.yaml` に共通化。
-6. plan の CUJ 表 (`/Users/shingosato/.claude/plans/cuj-e2e-test-parallel-wreath.md`)
-   と本 CLAUDE.md の表を更新。
-
-### 動作確認の段階
-
-| 変更の規模 | 走らせる flow |
-|---|---|
-| typo / コメント / ドキュメント | (なし or `pnpm test:e2e:smoke`) |
-| 新機能 / UI 変更 / ItemForm 修正 | `pnpm test:e2e:smoke` → `:core` → `:regression` |
-| リファクタ / 依存更新 | `pnpm test:e2e:regression` 必須 |
-| Maestro flow 自体の変更 | 個別 flow を `maestro test .maestro/<name>.yaml` |
-
-### ガッチャ早見表
-
-- **destructive な Alert button のラベルは `削除する` に統一**。背景に `削除`
-  テキスト (Pressable) があると Maestro が後ろを tap してしまう。
-- **ItemCard 等のリスト行に `accessibilityLabel` を付けない**。子の `<Text>`
-  が accessibility tree から消えて assertVisible が effective に動かなくなる。
-- **ItemForm の submit ボタンは ScrollView 末尾**。`tapOn id:'btn:submit'` の
-  前に必ず `scrollUntilVisible visibilityPercentage:50` を入れる。
-- **Stack push 後は tab bar が見えない**。`goto_settings` 等を再呼び出しする
-  前に `_helpers/launch.yaml` で cold restart する。
-- **Decision/Sale/WearLog Modal 内では `point: '50%, 18%'` を絶対に tap しない**。
-  Modal 背景 (backdrop) を tap してしまい cancel になる。
-
-## Conventions
-
-- Never use `any`. Prefer Zod-inferred types from `@seam/shared/schemas` for
-  anything crossing the persistence or import/export boundary.
-- Keep UI and domain logic separate: screens call repositories and domain
-  functions, never raw `db` queries from inside a component.
-- Japanese is the user-facing language; display labels live as `*_LABEL`
-  constants in `packages/shared/src/constants/` (e.g. `CATEGORY_LABEL`,
-  `ITEM_STATUS_LABEL`). Code identifiers stay in English.
-- When adding a new table: update `schema.ts`, run `pnpm drizzle:generate`,
-  add a Zod schema in `packages/shared/src/schemas/`, add a repository in
-  `packages/app/src/repositories/`, and extend the JSON export/import in
-  `src/backup/` if the data should round-trip.
+- **`any` を使わない。** 永続化・import/export 境界をまたぐ型は
+  `@seam/shared/schemas` の Zod 推論型を使う。TypeScript は strict
+  (`noUncheckedIndexedAccess`, `noImplicitReturns` 含む、`tsconfig.base.json`)。
+- ユーザー向け表示は日本語。表示ラベルは `packages/shared/src/constants/` の
+  `*_LABEL` 定数 (`CATEGORY_LABEL`, `ITEM_STATUS_LABEL` 等)。コード上の識別子は
+  英語のまま。
+- テーブルを追加するときは: `schema.ts` 更新 → `pnpm drizzle:generate` →
+  `packages/shared/src/schemas/` に Zod スキーマ → `src/repositories/` に
+  リポジトリ → データを往復させるなら `src/backup/` の JSON export/import も拡張。


### PR DESCRIPTION
## 概要

[Claude Code best practices — Write an effective CLAUDE.md](https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md) に沿って `CLAUDE.md` を整理した。

常時ロードされる `CLAUDE.md` には「広く適用されるルール」だけを残し、たまにしか要らないワークフローは Skill に切り出す、という方針に合わせている。記述言語は日本語に統一。

**329 行 → 136 行 (-59%)**

## 変更内容

### 1. E2E (Maestro) 詳細を Skill に切り出し

新規: `.claude/skills/e2e-maestro/SKILL.md` (155 行)

- flow 命名規則 / selector policy / DB state policy
- ガッチャ早見表 / 失敗時のセルフデバッグ手順
- 変更規模ごとの実行範囲、新画面追加時のワークフロー

`description` に「E2E」「Maestro」「testID」「flow が落ちる」等のトリガーを入れてあるので、UI 作業時には自動でロードされる。`CLAUDE.md` 側には「新機能 / UI 変更時は testID と flow を同 PR に含める」という判断ルールとポインタだけを残した。

### 2. 削除 (「コードを読めば分かること」)

- ルート一覧の逐一列挙 (`item/[id].tsx` 等)
- notifications / backup の説明的記述
- CI ワークフローの長文解説 → 箇条書きに圧縮

### 3. 追加 (これまで欠落していて事故要因になり得たもの)

- **lefthook** の存在 — pre-commit = Biome 整形のみ / pre-push = フル CI ゲート
- CI の `expo install --check` (Expo SDK peer 整合)
- `ios-build-check.yml` の存在
- リリース手順は `.claude/skills/release/` を参照、というポインタ

### 4. stale な記述の修正

- **Zustand は実際には未使用** (`package.json` にも import にも存在しない) → 削除
- `pnpm prebuild` は素の `expo prebuild` ではなく `scripts/prebuild.mjs`

## 補足

`packages/shared/package.json` が `"./locales": "./src/locales/index.ts"` を export しているが `src/locales/` は存在しない。現状 import 箇所が無いため実害は無いので、この PR では触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)