### PR TITLE
feat: subdivide garment categories (pants / jackets / shoes)

### DIFF
--- a/packages/app/src/db/migrations/0002_recategorize_legacy_categories.sql
+++ b/packages/app/src/db/migrations/0002_recategorize_legacy_categories.sql
@@ -1,0 +1,18 @@
+-- Custom SQL migration file, put your code below! --
+-- Recategorize legacy coarse categories into the finer-grained taxonomy.
+--   pants  -> denim_pants  (best-effort default; jeans are the most common bottoms)
+--   jacket -> other_jacket (closest generic jacket bucket)
+--   shoes  -> sneakers
+-- Applied to every table that stores a garment category.
+UPDATE `items` SET `category` = 'denim_pants' WHERE `category` = 'pants';--> statement-breakpoint
+UPDATE `items` SET `category` = 'other_jacket' WHERE `category` = 'jacket';--> statement-breakpoint
+UPDATE `items` SET `category` = 'sneakers' WHERE `category` = 'shoes';--> statement-breakpoint
+UPDATE `fit_anchors` SET `category` = 'denim_pants' WHERE `category` = 'pants';--> statement-breakpoint
+UPDATE `fit_anchors` SET `category` = 'other_jacket' WHERE `category` = 'jacket';--> statement-breakpoint
+UPDATE `fit_anchors` SET `category` = 'sneakers' WHERE `category` = 'shoes';--> statement-breakpoint
+UPDATE `measurement_rules` SET `category` = 'denim_pants' WHERE `category` = 'pants';--> statement-breakpoint
+UPDATE `measurement_rules` SET `category` = 'other_jacket' WHERE `category` = 'jacket';--> statement-breakpoint
+UPDATE `measurement_rules` SET `category` = 'sneakers' WHERE `category` = 'shoes';--> statement-breakpoint
+UPDATE `brand_guides` SET `category` = 'denim_pants' WHERE `category` = 'pants';--> statement-breakpoint
+UPDATE `brand_guides` SET `category` = 'other_jacket' WHERE `category` = 'jacket';--> statement-breakpoint
+UPDATE `brand_guides` SET `category` = 'sneakers' WHERE `category` = 'shoes';

--- a/packages/app/src/db/migrations/meta/0002_snapshot.json
+++ b/packages/app/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1397 @@
+{
+  "id": "dbfb843e-0840-406d-9412-8fa82d217e3a",
+  "prevId": "3ebdf8d6-628a-4c71-b9af-b3283f00d526",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "brand_checklist_states": {
+      "name": "brand_checklist_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand_guide_id": {
+          "name": "brand_guide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_item_key": {
+          "name": "checklist_item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "brand_checklist_states_item_guide_idx": {
+          "name": "brand_checklist_states_item_guide_idx",
+          "columns": [
+            "item_id",
+            "brand_guide_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "brand_checklist_states_item_id_items_id_fk": {
+          "name": "brand_checklist_states_item_id_items_id_fk",
+          "tableFrom": "brand_checklist_states",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "brand_checklist_states_brand_guide_id_brand_guides_id_fk": {
+          "name": "brand_checklist_states_brand_guide_id_brand_guides_id_fk",
+          "tableFrom": "brand_checklist_states",
+          "columnsFrom": [
+            "brand_guide_id"
+          ],
+          "tableTo": "brand_guides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brand_guides": {
+      "name": "brand_guides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_items": {
+          "name": "checklist_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "brand_guides_brand_idx": {
+          "name": "brand_guides_brand_idx",
+          "columns": [
+            "brand"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "candidate_evaluations": {
+      "name": "candidate_evaluations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_score": {
+          "name": "size_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_score": {
+          "name": "price_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_score": {
+          "name": "condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uniqueness_score": {
+          "name": "uniqueness_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duplicate_risk_score": {
+          "name": "duplicate_risk_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "candidate_evaluations_item_idx": {
+          "name": "candidate_evaluations_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "candidate_evaluations_item_id_items_id_fk": {
+          "name": "candidate_evaluations_item_id_items_id_fk",
+          "tableFrom": "candidate_evaluations",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "candidate_infos": {
+      "name": "candidate_infos",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auction_ends_at": {
+          "name": "auction_ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "easy_buy_price": {
+          "name": "easy_buy_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acceptable_price": {
+          "name": "acceptable_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_bid_price": {
+          "name": "max_bid_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seller_name": {
+          "name": "seller_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_description": {
+          "name": "listing_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_infos_item_id_items_id_fk": {
+          "name": "candidate_infos_item_id_items_id_fk",
+          "tableFrom": "candidate_infos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_logs": {
+      "name": "decision_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_at_decision": {
+          "name": "price_at_decision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_logs_item_idx": {
+          "name": "decision_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_logs_item_id_items_id_fk": {
+          "name": "decision_logs_item_id_items_id_fk",
+          "tableFrom": "decision_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_logs": {
+      "name": "failure_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "failure_logs_item_idx": {
+          "name": "failure_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_logs_item_id_items_id_fk": {
+          "name": "failure_logs_item_id_items_id_fk",
+          "tableFrom": "failure_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fit_anchors": {
+      "name": "fit_anchors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fit_anchors_category_idx": {
+          "name": "fit_anchors_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fit_anchors_item_id_items_id_fk": {
+          "name": "fit_anchors_item_id_items_id_fk",
+          "tableFrom": "fit_anchors",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_tags": {
+      "name": "item_tags",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_tags_item_id_items_id_fk": {
+          "name": "item_tags_item_id_items_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "item_tags_tag_id_tags_id_fk": {
+          "name": "item_tags_tag_id_tags_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "item_tags_item_id_tag_id_pk": {
+          "columns": [
+            "item_id",
+            "tag_id"
+          ],
+          "name": "item_tags_item_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_source": {
+          "name": "purchase_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_url": {
+          "name": "product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_rank": {
+          "name": "condition_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_notes": {
+          "name": "condition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fit_rating": {
+          "name": "fit_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_score": {
+          "name": "favorite_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_fit_anchor": {
+          "name": "is_fit_anchor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_sell_candidate": {
+          "name": "is_sell_candidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "items_status_idx": {
+          "name": "items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "items_category_idx": {
+          "name": "items_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "items_brand_idx": {
+          "name": "items_brand_idx",
+          "columns": [
+            "brand"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "measurement_rules": {
+      "name": "measurement_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "measurement_key": {
+          "name": "measurement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "measurement_rules_cat_key_idx": {
+          "name": "measurement_rules_cat_key_idx",
+          "columns": [
+            "category",
+            "measurement_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "measurements": {
+      "name": "measurements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "measurements_item_idx": {
+          "name": "measurements_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "measurements_item_id_items_id_fk": {
+          "name": "measurements_item_id_items_id_fk",
+          "tableFrom": "measurements",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "photos": {
+      "name": "photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_relative_path": {
+          "name": "thumbnail_relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photos_item_idx": {
+          "name": "photos_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "photos_item_id_items_id_fk": {
+          "name": "photos_item_id_items_id_fk",
+          "tableFrom": "photos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "price_snapshots": {
+      "name": "price_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "price_snapshots_item_idx": {
+          "name": "price_snapshots_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "price_snapshots_item_id_items_id_fk": {
+          "name": "price_snapshots_item_id_items_id_fk",
+          "tableFrom": "price_snapshots",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminders_item_idx": {
+          "name": "reminders_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_item_id_items_id_fk": {
+          "name": "reminders_item_id_items_id_fk",
+          "tableFrom": "reminders",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sale_infos": {
+      "name": "sale_infos",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sold_source": {
+          "name": "sold_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_infos_item_id_items_id_fk": {
+          "name": "sale_infos_item_id_items_id_fk",
+          "tableFrom": "sale_infos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wear_logs": {
+      "name": "wear_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worn_at": {
+          "name": "worn_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wear_logs_item_idx": {
+          "name": "wear_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wear_logs_item_id_items_id_fk": {
+          "name": "wear_logs_item_id_items_id_fk",
+          "tableFrom": "wear_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/app/src/db/migrations/meta/_journal.json
+++ b/packages/app/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777202836176,
       "tag": "0001_careless_omega_flight",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1784522703015,
+      "tag": "0002_recategorize_legacy_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/app/src/db/migrations/migrations.js
+++ b/packages/app/src/db/migrations/migrations.js
@@ -1,14 +1,14 @@
-// This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
-
 import journal from './meta/_journal.json';
 import m0000 from './0000_bouncy_gauntlet.sql';
 import m0001 from './0001_careless_omega_flight.sql';
+import m0002 from './0002_recategorize_legacy_categories.sql';
 
   export default {
     journal,
     migrations: {
       m0000,
-m0001
+m0001,
+m0002
     }
   }
   

--- a/packages/app/src/stats/aggregators.test.ts
+++ b/packages/app/src/stats/aggregators.test.ts
@@ -102,9 +102,9 @@ describe('findDuplicateClusters', () => {
     const items = [
       baseItem({ id: 'a1', category: 'shirt', brand: 'A', color: 'red' }),
       baseItem({ id: 'a2', category: 'shirt', brand: 'A', color: 'red' }),
-      baseItem({ id: 'b1', category: 'pants', brand: 'B', color: 'blue' }),
-      baseItem({ id: 'b2', category: 'pants', brand: 'B', color: 'blue' }),
-      baseItem({ id: 'b3', category: 'pants', brand: 'B', color: 'blue' }),
+      baseItem({ id: 'b1', category: 'denim_pants', brand: 'B', color: 'blue' }),
+      baseItem({ id: 'b2', category: 'denim_pants', brand: 'B', color: 'blue' }),
+      baseItem({ id: 'b3', category: 'denim_pants', brand: 'B', color: 'blue' }),
     ];
     const clusters = findDuplicateClusters(items);
     expect(clusters[0]?.itemIds).toHaveLength(3);

--- a/packages/domain/src/compare/compareMeasurements.test.ts
+++ b/packages/domain/src/compare/compareMeasurements.test.ts
@@ -51,15 +51,15 @@ describe('compareMeasurements', () => {
     const reference2: Measurement[] = [
       { id: 'r-jpSize', itemId: 'r', key: 'jpSize', value: 27, unit: 'us' },
     ];
-    expect(compareMeasurements(candidate, reference, 'shoes')).toEqual([]);
-    const diffs = compareMeasurements(candidate2, reference2, 'shoes');
+    expect(compareMeasurements(candidate, reference, 'sneakers')).toEqual([]);
+    const diffs = compareMeasurements(candidate2, reference2, 'sneakers');
     expect(diffs).toHaveLength(1);
     expect(diffs[0]?.comparable).toBe(false);
     expect(diffs[0]?.diffCm).toBe(0);
   });
 
   it('returns 0% for reference value of 0', () => {
-    const diffs = compareMeasurements([m('c', 'inseam', 5)], [m('r', 'inseam', 0)], 'pants');
+    const diffs = compareMeasurements([m('c', 'inseam', 5)], [m('r', 'inseam', 0)], 'denim_pants');
     expect(diffs).toHaveLength(1);
     expect(diffs[0]?.diffPct).toBe(0);
   });
@@ -67,7 +67,7 @@ describe('compareMeasurements', () => {
   it('only considers keys in the category group', () => {
     const candidate = [m('c', 'waist', 80), m('c', 'shoulderWidth', 50)];
     const reference = [m('r', 'waist', 78), m('r', 'shoulderWidth', 48)];
-    const diffs = compareMeasurements(candidate, reference, 'pants');
+    const diffs = compareMeasurements(candidate, reference, 'denim_pants');
     expect(diffs.map((d) => d.key)).toEqual(['waist']);
   });
 });

--- a/packages/domain/src/compare/getMeasurementDiffSeverity.test.ts
+++ b/packages/domain/src/compare/getMeasurementDiffSeverity.test.ts
@@ -64,7 +64,7 @@ describe('getMeasurementDiffSeverity', () => {
 
   it('returns "different" for non-comparable diffs (no signal)', () => {
     const d = diff({ comparable: false, diffCm: 0, diffPct: 0 });
-    expect(getMeasurementDiffSeverity(d, 'shoes')).toBe('different');
+    expect(getMeasurementDiffSeverity(d, 'sneakers')).toBe('different');
   });
 
   it('uses pants thresholds for pants category', () => {
@@ -78,6 +78,6 @@ describe('getMeasurementDiffSeverity', () => {
       candidateValue: 82.5,
       referenceValue: 80,
     });
-    expect(getMeasurementDiffSeverity(d, 'pants')).toBe('different');
+    expect(getMeasurementDiffSeverity(d, 'denim_pants')).toBe('different');
   });
 });

--- a/packages/domain/src/compare/suggestSimilarItems.test.ts
+++ b/packages/domain/src/compare/suggestSimilarItems.test.ts
@@ -29,7 +29,10 @@ describe('suggestSimilarItems', () => {
   });
 
   it('filters by same category by default', () => {
-    const owned = [item({ id: 'a', category: 't_shirt' }), item({ id: 'b', category: 'pants' })];
+    const owned = [
+      item({ id: 'a', category: 't_shirt' }),
+      item({ id: 'b', category: 'denim_pants' }),
+    ];
     expect(suggestSimilarItems(candidate, owned).map((i) => i.id)).toEqual(['a']);
   });
 
@@ -68,7 +71,7 @@ describe('suggestSimilarItems', () => {
 
   it('returns items across categories when sameCategory=false', () => {
     const owned = [
-      item({ id: 'pants', category: 'pants' }),
+      item({ id: 'pants', category: 'denim_pants' }),
       item({ id: 'shirt', category: 't_shirt' }),
     ];
     const result = suggestSimilarItems(candidate, owned, { sameCategory: false });

--- a/packages/domain/src/extraction/extractMeasurementsFromText.test.ts
+++ b/packages/domain/src/extraction/extractMeasurementsFromText.test.ts
@@ -85,7 +85,7 @@ describe('extractMeasurementsFromText', () => {
 
   it('11) extracts pants-specific keys', () => {
     const text = 'ウエスト 91cm 股下 76cm ワタリ 34cm 裾幅 23cm';
-    const result = extractMeasurementsFromText(text, 'pants');
+    const result = extractMeasurementsFromText(text, 'denim_pants');
     expect(findValue(result, 'waist')).toBe(91);
     expect(findValue(result, 'inseam')).toBe(76);
     expect(findValue(result, 'thighWidth')).toBe(34);
@@ -95,7 +95,7 @@ describe('extractMeasurementsFromText', () => {
 
   it('12) maps inch (W32inch) to cm for waist', () => {
     const text = 'W32inch 股下 76cm';
-    const result = extractMeasurementsFromText(text, 'pants');
+    const result = extractMeasurementsFromText(text, 'denim_pants');
     // 32 inch ≈ 81.3 cm
     const waist = findValue(result, 'waist');
     expect(waist).toBeDefined();
@@ -105,7 +105,7 @@ describe('extractMeasurementsFromText', () => {
 
   it('13) plain inch suffix (32inch) → cm', () => {
     const text = 'ウエスト 32inch';
-    const result = extractMeasurementsFromText(text, 'pants');
+    const result = extractMeasurementsFromText(text, 'denim_pants');
     const waist = findValue(result, 'waist');
     expect(waist).toBeCloseTo(81.3, 1);
     // Stored with cm unit after conversion
@@ -215,7 +215,7 @@ USA製 90s 古着`;
 股下 76cm
 ワタリ 32cm
 裾幅 21cm`;
-    const result = extractMeasurementsFromText(text, 'pants');
+    const result = extractMeasurementsFromText(text, 'denim_pants');
     expect(findValue(result, 'waist')).toBe(81);
     expect(findValue(result, 'inseam')).toBe(76);
     expect(findValue(result, 'thighWidth')).toBe(32);

--- a/packages/domain/src/rules/evaluatePersonalMeasurementRules.test.ts
+++ b/packages/domain/src/rules/evaluatePersonalMeasurementRules.test.ts
@@ -55,7 +55,7 @@ describe('evaluatePersonalMeasurementRules', () => {
   });
 
   it('skips rules for other categories', () => {
-    const r = rule({ category: 'pants' });
+    const r = rule({ category: 'denim_pants' });
     const violations = evaluatePersonalMeasurementRules(
       [m('i', 'shoulderWidth', 45)],
       [r],
@@ -88,12 +88,16 @@ describe('evaluatePersonalMeasurementRules', () => {
 
   it('skips shoes-size rules when units differ', () => {
     const r = rule({
-      category: 'shoes',
+      category: 'sneakers',
       measurementKey: 'jpSize',
       operator: 'gt',
       value: 28,
     });
-    const violations = evaluatePersonalMeasurementRules([m('i', 'jpSize', 9, 'us')], [r], 'shoes');
+    const violations = evaluatePersonalMeasurementRules(
+      [m('i', 'jpSize', 9, 'us')],
+      [r],
+      'sneakers',
+    );
     expect(violations).toEqual([]);
   });
 

--- a/packages/domain/src/scoring/calculateDuplicateRisk.test.ts
+++ b/packages/domain/src/scoring/calculateDuplicateRisk.test.ts
@@ -20,7 +20,7 @@ describe('calculateDuplicateRisk', () => {
     status: 'wishlist',
     brand: 'Levi’s',
     color: 'indigo',
-    category: 'pants',
+    category: 'denim_pants',
   });
 
   it('returns 0 when ownedItems is empty', () => {
@@ -33,55 +33,57 @@ describe('calculateDuplicateRisk', () => {
   });
 
   it('returns 5 for same category only', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: 'Lee', color: 'black' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Lee', color: 'black' })];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(5);
   });
 
   it('returns 15 for same category + color', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: 'Lee', color: 'indigo' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Lee', color: 'indigo' })];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(15);
   });
 
   it('returns 25 for same category + brand', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: 'Levi’s', color: 'black' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Levi’s', color: 'black' })];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(25);
   });
 
   it('returns 40 for same category + brand + color', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: 'Levi’s', color: 'indigo' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Levi’s', color: 'indigo' })];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(40);
   });
 
   it('uses the worst (highest) match across many owned items', () => {
     const owned = [
-      item({ id: '1', category: 'pants', brand: 'Lee', color: 'black' }), // 5
-      item({ id: '2', category: 'pants', brand: 'Lee', color: 'indigo' }), // 15
-      item({ id: '3', category: 'pants', brand: 'Levi’s', color: 'indigo' }), // 40
+      item({ id: '1', category: 'denim_pants', brand: 'Lee', color: 'black' }), // 5
+      item({ id: '2', category: 'denim_pants', brand: 'Lee', color: 'indigo' }), // 15
+      item({ id: '3', category: 'denim_pants', brand: 'Levi’s', color: 'indigo' }), // 40
     ];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(40);
   });
 
   it('compares case- and whitespace-insensitively', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: '  LEVI’S ', color: 'INDIGO ' })];
+    const owned = [
+      item({ id: '1', category: 'denim_pants', brand: '  LEVI’S ', color: 'INDIGO ' }),
+    ];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(40);
   });
 
   it('treats undefined brand/color as no-match (no false positives)', () => {
     const noBrandCandidate = item({
       id: 'c',
-      category: 'pants',
+      category: 'denim_pants',
       brand: undefined,
       color: undefined,
       status: 'wishlist',
     });
-    const owned = [item({ id: '1', category: 'pants', brand: 'Levi’s', color: 'indigo' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Levi’s', color: 'indigo' })];
     expect(calculateDuplicateRisk(noBrandCandidate, owned)).toBe(5);
   });
 
   it('skips the candidate itself when present in ownedItems', () => {
     const owned = [
       candidate, // self should not count even though it would be a perfect 40
-      item({ id: '1', category: 'pants', brand: 'Lee', color: 'black' }),
+      item({ id: '1', category: 'denim_pants', brand: 'Lee', color: 'black' }),
     ];
     expect(calculateDuplicateRisk(candidate, owned)).toBe(5);
   });

--- a/packages/domain/src/scoring/calculateUniquenessScore.test.ts
+++ b/packages/domain/src/scoring/calculateUniquenessScore.test.ts
@@ -21,7 +21,7 @@ describe('calculateUniquenessScore', () => {
   const candidate = item({
     id: 'cand',
     status: 'wishlist',
-    category: 'pants',
+    category: 'denim_pants',
     brand: 'Levi’s',
   });
 
@@ -30,56 +30,59 @@ describe('calculateUniquenessScore', () => {
   });
 
   it('returns 100 when no owned item shares the category', () => {
-    const owned = [item({ id: '1', category: 't_shirt' }), item({ id: '2', category: 'jacket' })];
+    const owned = [
+      item({ id: '1', category: 't_shirt' }),
+      item({ id: '2', category: 'other_jacket' }),
+    ];
     expect(calculateUniquenessScore(candidate, owned)).toBe(100);
   });
 
   it('returns 80 for 1 same-category, no brand overlap', () => {
-    const owned = [item({ id: '1', category: 'pants', brand: 'Lee' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Lee' })];
     expect(calculateUniquenessScore(candidate, owned)).toBe(80);
   });
 
   it('returns 80 for 2 same-category items', () => {
-    const owned = make(2, { category: 'pants', brand: 'Lee' });
+    const owned = make(2, { category: 'denim_pants', brand: 'Lee' });
     expect(calculateUniquenessScore(candidate, owned)).toBe(80);
   });
 
   it('returns 60 for 3-4 same-category items', () => {
-    const owned3 = make(3, { category: 'pants', brand: 'Lee' });
-    const owned4 = make(4, { category: 'pants', brand: 'Lee' });
+    const owned3 = make(3, { category: 'denim_pants', brand: 'Lee' });
+    const owned4 = make(4, { category: 'denim_pants', brand: 'Lee' });
     expect(calculateUniquenessScore(candidate, owned3)).toBe(60);
     expect(calculateUniquenessScore(candidate, owned4)).toBe(60);
   });
 
   it('returns 40 for 5-6 same-category items', () => {
-    expect(calculateUniquenessScore(candidate, make(5, { category: 'pants', brand: 'Lee' }))).toBe(
-      40,
-    );
-    expect(calculateUniquenessScore(candidate, make(6, { category: 'pants', brand: 'Lee' }))).toBe(
-      40,
-    );
+    expect(
+      calculateUniquenessScore(candidate, make(5, { category: 'denim_pants', brand: 'Lee' })),
+    ).toBe(40);
+    expect(
+      calculateUniquenessScore(candidate, make(6, { category: 'denim_pants', brand: 'Lee' })),
+    ).toBe(40);
   });
 
   it('returns 20 for 7+ same-category items', () => {
-    expect(calculateUniquenessScore(candidate, make(7, { category: 'pants', brand: 'Lee' }))).toBe(
-      20,
-    );
+    expect(
+      calculateUniquenessScore(candidate, make(7, { category: 'denim_pants', brand: 'Lee' })),
+    ).toBe(20);
   });
 
   it('subtracts 5 per same-brand item', () => {
     // 1 jeans (base 80), all also same brand → 80 - 1*5 = 75
-    const owned = [item({ id: '1', category: 'pants', brand: 'Levi’s' })];
+    const owned = [item({ id: '1', category: 'denim_pants', brand: 'Levi’s' })];
     expect(calculateUniquenessScore(candidate, owned)).toBe(75);
   });
 
   it('clamps at 0 when many same-brand items dominate', () => {
-    const owned = make(20, { category: 'pants', brand: 'Levi’s' });
+    const owned = make(20, { category: 'denim_pants', brand: 'Levi’s' });
     expect(calculateUniquenessScore(candidate, owned)).toBe(0);
   });
 
   it('treats undefined candidate brand as no brand penalty', () => {
-    const c = item({ id: 'c2', status: 'wishlist', category: 'pants', brand: undefined });
-    const owned = make(1, { category: 'pants', brand: 'Levi’s' });
+    const c = item({ id: 'c2', status: 'wishlist', category: 'denim_pants', brand: undefined });
+    const owned = make(1, { category: 'denim_pants', brand: 'Levi’s' });
     expect(calculateUniquenessScore(c, owned)).toBe(80);
   });
 

--- a/packages/shared/src/constants/categories.ts
+++ b/packages/shared/src/constants/categories.ts
@@ -1,13 +1,31 @@
 export const GARMENT_CATEGORIES = [
+  // Tops
   'hoodie',
   'sweatshirt',
   't_shirt',
   'shirt',
-  'jacket',
+  // Jackets (measured as tops)
+  'denim_jacket',
+  'swing_top',
+  'coach_jacket',
+  'boa_jacket',
+  'leather_jacket',
+  'military_jacket',
+  'mountain_parka',
+  'tailored_jacket',
+  'down_jacket',
+  'other_jacket',
   'coat',
-  'pants',
+  // Pants
+  'denim_pants',
+  'slacks',
+  'chino',
+  'work_pants',
   'shorts',
-  'shoes',
+  // Shoes
+  'sneakers',
+  'sandals',
+  // Other
   'bag',
   'accessory',
   'other',
@@ -20,24 +38,52 @@ export const TOP_CATEGORIES: readonly GarmentCategory[] = [
   'sweatshirt',
   't_shirt',
   'shirt',
-  'jacket',
+  'denim_jacket',
+  'swing_top',
+  'coach_jacket',
+  'boa_jacket',
+  'leather_jacket',
+  'military_jacket',
+  'mountain_parka',
+  'tailored_jacket',
+  'down_jacket',
+  'other_jacket',
   'coat',
 ];
 
-export const PANTS_CATEGORIES: readonly GarmentCategory[] = ['pants', 'shorts'];
+export const PANTS_CATEGORIES: readonly GarmentCategory[] = [
+  'denim_pants',
+  'slacks',
+  'chino',
+  'work_pants',
+  'shorts',
+];
 
-export const SHOES_CATEGORIES: readonly GarmentCategory[] = ['shoes'];
+export const SHOES_CATEGORIES: readonly GarmentCategory[] = ['sneakers', 'sandals'];
 
 export const CATEGORY_LABEL: Record<GarmentCategory, string> = {
   hoodie: 'パーカー',
   sweatshirt: 'スウェット',
   t_shirt: 'Tシャツ',
   shirt: 'シャツ',
-  jacket: 'ジャケット',
+  denim_jacket: 'デニムジャケット',
+  swing_top: 'スイングトップ',
+  coach_jacket: 'コーチジャケット',
+  boa_jacket: 'ボアジャケット',
+  leather_jacket: 'レザージャケット',
+  military_jacket: 'ミリタリージャケット',
+  mountain_parka: 'マウンテンパーカー',
+  tailored_jacket: 'テーラードジャケット',
+  down_jacket: 'ダウンジャケット',
+  other_jacket: 'その他ジャケット',
   coat: 'コート',
-  pants: 'パンツ',
+  denim_pants: 'デニム',
+  slacks: 'スラックス',
+  chino: 'チノ',
+  work_pants: 'ワークパンツ',
   shorts: 'ショーツ',
-  shoes: '靴',
+  sneakers: 'スニーカー',
+  sandals: 'サンダル',
   bag: 'バッグ',
   accessory: '小物',
   other: 'その他',

--- a/packages/shared/src/constants/measurementKeys.test.ts
+++ b/packages/shared/src/constants/measurementKeys.test.ts
@@ -13,11 +13,11 @@ describe('measurementKeysFor', () => {
   });
 
   it('returns pants keys for pants', () => {
-    expect(measurementKeysFor('pants')).toEqual(PANTS_MEASUREMENT_KEYS);
+    expect(measurementKeysFor('denim_pants')).toEqual(PANTS_MEASUREMENT_KEYS);
   });
 
   it('returns shoes keys for shoes', () => {
-    expect(measurementKeysFor('shoes')).toEqual(SHOES_MEASUREMENT_KEYS);
+    expect(measurementKeysFor('sneakers')).toEqual(SHOES_MEASUREMENT_KEYS);
   });
 
   it('returns empty for accessory/bag/other', () => {


### PR DESCRIPTION
## 概要

カテゴリの粒度が大きすぎた `pants` / `jacket` / `shoes` を、比較精度が上がるよう細分化する。

| グループ | 変更後のカテゴリ |
|---|---|
| パンツ | デニム / スラックス / チノ / ワークパンツ（ショーツは維持） |
| ジャケット | デニム / スイングトップ / コーチ / ボア / レザー / ミリタリー / マウンテンパーカー / テーラード / ダウン / その他ジャケット（コートは別カテゴリのまま維持） |
| 靴 | スニーカー / サンダル |

## 実装方針

- 分類は `@seam/shared` の `constants/categories.ts`（`GARMENT_CATEGORIES`）に一元化。Picker・ラベル・採寸グループ（top/pants/shoes）・重複判定・類似度・統計はすべてこの enum から自動導出されるため、実質この 1 ファイルの変更で UI まで反映される。
- ジャケット系は全て top グループ（肩幅・身幅・着丈・袖丈）、パンツ 4 種は pants グループ、靴 2 種は shoes グループにマッピング。

## 既存データの移行

旧値を enum から削除すると読み込みで Zod が落ちるため、カスタム Drizzle マイグレーション `0002_recategorize_legacy_categories` で `items` / `fit_anchors` / `measurement_rules` / `brand_guides` の 4 テーブルを一括変換（アプリ起動時に自動適用）。

- `pants → denim_pants`
- `jacket → other_jacket`
- `shoes → sneakers`

⚠️ `pants → デニム` はベストエフォートの推測（ヴィンテージではジーンズが最多という理由）。実機の既存パンツが実際にはチノ/スラックスだった場合は、移行後にアプリ内で個別に選び直す想定。

## テスト

- 旧カテゴリを代表値に使っていたテスト 9 ファイルを、意味を保って新カテゴリ（pants系→`denim_pants`、靴系→`sneakers`、トップス系→`other_jacket`）に更新。
- `drizzle:check` / `typecheck` / `test`（222 件）/ `lint` / `format` すべて green。
- E2E は simulator/Metro が必要なため未実行。ただし Maestro flow はカテゴリを `t_shirt` デフォルトでしか選んでおらず旧カテゴリ値への直接参照が無いため flow 破壊は無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)