### PR TITLE
ci(release): push source.json to main via write deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # main の branch ruleset (required status checks) を bot の GITHUB_TOKEN は
+          # bypass できないため、"Commit & push source.json" が拒否される。write 権限の
+          # deploy key で push すると ruleset の DeployKey bypass が効く。ssh-key を渡すと
+          # checkout が origin を SSH remote に設定し、以降の git push が鍵認証で通る。
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## 背景

v0.11.0 リリース時、`release.yml` の `release` job 最終 step **`Commit & push source.json`** が失敗した。

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 3 of 3 required status checks are expected.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

`github-actions[bot]` (デフォルト `GITHUB_TOKEN`) が `docs/source.json` 更新 commit を main へ直 push しようとしたが、main の branch ruleset (`required_status_checks`) を bot は bypass できず拒否された。IPA build と GitHub Release 作成までは成功していたため、v0.11.0 の source.json は手動で復旧済み。

## 変更

`release` job の `actions/checkout` に write 権限の deploy key (`secrets.RELEASE_DEPLOY_KEY`) を渡す。`ssh-key` を指定すると checkout が `origin` を SSH remote に設定し、以降の `git push origin HEAD:main` が deploy key で認証される。ruleset の bypass に **DeployKey** を追加済みなので、この push は required status checks を bypass して通る。

## 事前設定（設定済み）

- [x] write 権限付き deploy key `seam-release-deploy-key` を登録 (id 157767202)
- [x] private key を secret `RELEASE_DEPLOY_KEY` に設定
- [x] ruleset `15565151` の bypass に DeployKey (always) を追加（admin role bypass は維持）

## 確認

次回リリース (`/release`) で `release` job が最後まで success することで検証する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
