### PR TITLE
feat: add tank top / cardigan and split shirt into short/long sleeve

### DIFF
--- a/packages/app/src/db/migrations/0003_split_shirt_category.sql
+++ b/packages/app/src/db/migrations/0003_split_shirt_category.sql
@@ -1,0 +1,9 @@
+-- Custom SQL migration file, put your code below! --
+-- Split the legacy `shirt` category into short_sleeve_shirt / long_sleeve_shirt.
+-- Sleeve length is unknown for pre-split rows, so remap to long_sleeve_shirt as a
+-- best-effort default (oxford / flannel / western / knit dress shirts dominate).
+-- Applied to every table that stores a garment category.
+UPDATE `items` SET `category` = 'long_sleeve_shirt' WHERE `category` = 'shirt';--> statement-breakpoint
+UPDATE `fit_anchors` SET `category` = 'long_sleeve_shirt' WHERE `category` = 'shirt';--> statement-breakpoint
+UPDATE `measurement_rules` SET `category` = 'long_sleeve_shirt' WHERE `category` = 'shirt';--> statement-breakpoint
+UPDATE `brand_guides` SET `category` = 'long_sleeve_shirt' WHERE `category` = 'shirt';

--- a/packages/app/src/db/migrations/meta/0003_snapshot.json
+++ b/packages/app/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1397 @@
+{
+  "id": "fe504728-5165-48ba-9131-3d4b1de8b422",
+  "prevId": "dbfb843e-0840-406d-9412-8fa82d217e3a",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "brand_checklist_states": {
+      "name": "brand_checklist_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand_guide_id": {
+          "name": "brand_guide_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_item_key": {
+          "name": "checklist_item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "brand_checklist_states_item_guide_idx": {
+          "name": "brand_checklist_states_item_guide_idx",
+          "columns": [
+            "item_id",
+            "brand_guide_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "brand_checklist_states_item_id_items_id_fk": {
+          "name": "brand_checklist_states_item_id_items_id_fk",
+          "tableFrom": "brand_checklist_states",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "brand_checklist_states_brand_guide_id_brand_guides_id_fk": {
+          "name": "brand_checklist_states_brand_guide_id_brand_guides_id_fk",
+          "tableFrom": "brand_checklist_states",
+          "columnsFrom": [
+            "brand_guide_id"
+          ],
+          "tableTo": "brand_guides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brand_guides": {
+      "name": "brand_guides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checklist_items": {
+          "name": "checklist_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "brand_guides_brand_idx": {
+          "name": "brand_guides_brand_idx",
+          "columns": [
+            "brand"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "candidate_evaluations": {
+      "name": "candidate_evaluations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_score": {
+          "name": "size_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_score": {
+          "name": "price_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition_score": {
+          "name": "condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uniqueness_score": {
+          "name": "uniqueness_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duplicate_risk_score": {
+          "name": "duplicate_risk_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "candidate_evaluations_item_idx": {
+          "name": "candidate_evaluations_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "candidate_evaluations_item_id_items_id_fk": {
+          "name": "candidate_evaluations_item_id_items_id_fk",
+          "tableFrom": "candidate_evaluations",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "candidate_infos": {
+      "name": "candidate_infos",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auction_ends_at": {
+          "name": "auction_ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "easy_buy_price": {
+          "name": "easy_buy_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acceptable_price": {
+          "name": "acceptable_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_bid_price": {
+          "name": "max_bid_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seller_name": {
+          "name": "seller_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_description": {
+          "name": "listing_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "candidate_infos_item_id_items_id_fk": {
+          "name": "candidate_infos_item_id_items_id_fk",
+          "tableFrom": "candidate_infos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_logs": {
+      "name": "decision_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_at_decision": {
+          "name": "price_at_decision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_logs_item_idx": {
+          "name": "decision_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_logs_item_id_items_id_fk": {
+          "name": "decision_logs_item_id_items_id_fk",
+          "tableFrom": "decision_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_logs": {
+      "name": "failure_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "failure_logs_item_idx": {
+          "name": "failure_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_logs_item_id_items_id_fk": {
+          "name": "failure_logs_item_id_items_id_fk",
+          "tableFrom": "failure_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fit_anchors": {
+      "name": "fit_anchors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fit_anchors_category_idx": {
+          "name": "fit_anchors_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fit_anchors_item_id_items_id_fk": {
+          "name": "fit_anchors_item_id_items_id_fk",
+          "tableFrom": "fit_anchors",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_tags": {
+      "name": "item_tags",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_tags_item_id_items_id_fk": {
+          "name": "item_tags_item_id_items_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "item_tags_tag_id_tags_id_fk": {
+          "name": "item_tags_tag_id_tags_id_fk",
+          "tableFrom": "item_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "item_tags_item_id_tag_id_pk": {
+          "columns": [
+            "item_id",
+            "tag_id"
+          ],
+          "name": "item_tags_item_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_source": {
+          "name": "purchase_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_url": {
+          "name": "product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_rank": {
+          "name": "condition_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_notes": {
+          "name": "condition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fit_rating": {
+          "name": "fit_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_score": {
+          "name": "favorite_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_fit_anchor": {
+          "name": "is_fit_anchor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_sell_candidate": {
+          "name": "is_sell_candidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "items_status_idx": {
+          "name": "items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "items_category_idx": {
+          "name": "items_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "items_brand_idx": {
+          "name": "items_brand_idx",
+          "columns": [
+            "brand"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "measurement_rules": {
+      "name": "measurement_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "measurement_key": {
+          "name": "measurement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "measurement_rules_cat_key_idx": {
+          "name": "measurement_rules_cat_key_idx",
+          "columns": [
+            "category",
+            "measurement_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "measurements": {
+      "name": "measurements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "measurements_item_idx": {
+          "name": "measurements_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "measurements_item_id_items_id_fk": {
+          "name": "measurements_item_id_items_id_fk",
+          "tableFrom": "measurements",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "photos": {
+      "name": "photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_relative_path": {
+          "name": "thumbnail_relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photos_item_idx": {
+          "name": "photos_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "photos_item_id_items_id_fk": {
+          "name": "photos_item_id_items_id_fk",
+          "tableFrom": "photos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "price_snapshots": {
+      "name": "price_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "price_snapshots_item_idx": {
+          "name": "price_snapshots_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "price_snapshots_item_id_items_id_fk": {
+          "name": "price_snapshots_item_id_items_id_fk",
+          "tableFrom": "price_snapshots",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminders_item_idx": {
+          "name": "reminders_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_item_id_items_id_fk": {
+          "name": "reminders_item_id_items_id_fk",
+          "tableFrom": "reminders",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sale_infos": {
+      "name": "sale_infos",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sold_source": {
+          "name": "sold_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_infos_item_id_items_id_fk": {
+          "name": "sale_infos_item_id_items_id_fk",
+          "tableFrom": "sale_infos",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wear_logs": {
+      "name": "wear_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worn_at": {
+          "name": "worn_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wear_logs_item_idx": {
+          "name": "wear_logs_item_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wear_logs_item_id_items_id_fk": {
+          "name": "wear_logs_item_id_items_id_fk",
+          "tableFrom": "wear_logs",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "tableTo": "items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/app/src/db/migrations/meta/_journal.json
+++ b/packages/app/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784522703015,
       "tag": "0002_recategorize_legacy_categories",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1784525616817,
+      "tag": "0003_split_shirt_category",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/app/src/db/migrations/migrations.js
+++ b/packages/app/src/db/migrations/migrations.js
@@ -2,13 +2,15 @@ import journal from './meta/_journal.json';
 import m0000 from './0000_bouncy_gauntlet.sql';
 import m0001 from './0001_careless_omega_flight.sql';
 import m0002 from './0002_recategorize_legacy_categories.sql';
+import m0003 from './0003_split_shirt_category.sql';
 
   export default {
     journal,
     migrations: {
       m0000,
 m0001,
-m0002
+m0002,
+m0003
     }
   }
   

--- a/packages/app/src/repositories/itemRepository.sold.test.ts
+++ b/packages/app/src/repositories/itemRepository.sold.test.ts
@@ -13,7 +13,7 @@ const baseSold = (overrides: Partial<SoldItem>): SoldItem => {
     id: overrides.id ?? 'i',
     status: 'sold',
     name: overrides.name ?? 'name',
-    category: overrides.category ?? 'shirt',
+    category: overrides.category ?? 'long_sleeve_shirt',
     isFitAnchor: false,
     isSellCandidate: false,
     createdAt: '2026-01-01T00:00:00.000Z',

--- a/packages/app/src/stats/aggregators.test.ts
+++ b/packages/app/src/stats/aggregators.test.ts
@@ -16,7 +16,7 @@ const baseItem = (overrides: Partial<GarmentItem>): GarmentItem =>
     id: 'i',
     status: 'owned',
     name: 'name',
-    category: 'shirt',
+    category: 'long_sleeve_shirt',
     isFitAnchor: false,
     isSellCandidate: false,
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -70,9 +70,9 @@ describe('daysSince', () => {
 describe('findDuplicateClusters', () => {
   it('groups items sharing category+brand+color', () => {
     const items = [
-      baseItem({ id: 'a', category: 'shirt', brand: 'X', color: 'black' }),
-      baseItem({ id: 'b', category: 'shirt', brand: 'X', color: 'black' }),
-      baseItem({ id: 'c', category: 'shirt', brand: 'Y', color: 'black' }),
+      baseItem({ id: 'a', category: 'long_sleeve_shirt', brand: 'X', color: 'black' }),
+      baseItem({ id: 'b', category: 'long_sleeve_shirt', brand: 'X', color: 'black' }),
+      baseItem({ id: 'c', category: 'long_sleeve_shirt', brand: 'Y', color: 'black' }),
     ];
     const clusters = findDuplicateClusters(items);
     expect(clusters).toHaveLength(1);
@@ -81,16 +81,16 @@ describe('findDuplicateClusters', () => {
 
   it('skips items missing both brand and color', () => {
     const items = [
-      baseItem({ id: 'a', category: 'shirt' }),
-      baseItem({ id: 'b', category: 'shirt' }),
+      baseItem({ id: 'a', category: 'long_sleeve_shirt' }),
+      baseItem({ id: 'b', category: 'long_sleeve_shirt' }),
     ];
     expect(findDuplicateClusters(items)).toHaveLength(0);
   });
 
   it('groups by brand only when color is missing', () => {
     const items = [
-      baseItem({ id: 'a', category: 'shirt', brand: 'X' }),
-      baseItem({ id: 'b', category: 'shirt', brand: 'X' }),
+      baseItem({ id: 'a', category: 'long_sleeve_shirt', brand: 'X' }),
+      baseItem({ id: 'b', category: 'long_sleeve_shirt', brand: 'X' }),
     ];
     const clusters = findDuplicateClusters(items);
     expect(clusters).toHaveLength(1);
@@ -100,8 +100,8 @@ describe('findDuplicateClusters', () => {
 
   it('returns largest clusters first', () => {
     const items = [
-      baseItem({ id: 'a1', category: 'shirt', brand: 'A', color: 'red' }),
-      baseItem({ id: 'a2', category: 'shirt', brand: 'A', color: 'red' }),
+      baseItem({ id: 'a1', category: 'long_sleeve_shirt', brand: 'A', color: 'red' }),
+      baseItem({ id: 'a2', category: 'long_sleeve_shirt', brand: 'A', color: 'red' }),
       baseItem({ id: 'b1', category: 'denim_pants', brand: 'B', color: 'blue' }),
       baseItem({ id: 'b2', category: 'denim_pants', brand: 'B', color: 'blue' }),
       baseItem({ id: 'b3', category: 'denim_pants', brand: 'B', color: 'blue' }),
@@ -113,8 +113,8 @@ describe('findDuplicateClusters', () => {
 
   it('treats whitespace-only brand as missing', () => {
     const items = [
-      baseItem({ id: 'a', category: 'shirt', brand: '   ', color: 'red' }),
-      baseItem({ id: 'b', category: 'shirt', brand: '', color: 'red' }),
+      baseItem({ id: 'a', category: 'long_sleeve_shirt', brand: '   ', color: 'red' }),
+      baseItem({ id: 'b', category: 'long_sleeve_shirt', brand: '', color: 'red' }),
     ];
     const clusters = findDuplicateClusters(items);
     // brand normalized away, color shared → still clusters

--- a/packages/shared/src/constants/categories.ts
+++ b/packages/shared/src/constants/categories.ts
@@ -2,8 +2,11 @@ export const GARMENT_CATEGORIES = [
   // Tops
   'hoodie',
   'sweatshirt',
+  'cardigan',
   't_shirt',
-  'shirt',
+  'tank_top',
+  'short_sleeve_shirt',
+  'long_sleeve_shirt',
   // Jackets (measured as tops)
   'denim_jacket',
   'swing_top',
@@ -36,8 +39,11 @@ export type GarmentCategory = (typeof GARMENT_CATEGORIES)[number];
 export const TOP_CATEGORIES: readonly GarmentCategory[] = [
   'hoodie',
   'sweatshirt',
+  'cardigan',
   't_shirt',
-  'shirt',
+  'tank_top',
+  'short_sleeve_shirt',
+  'long_sleeve_shirt',
   'denim_jacket',
   'swing_top',
   'coach_jacket',
@@ -64,8 +70,11 @@ export const SHOES_CATEGORIES: readonly GarmentCategory[] = ['sneakers', 'sandal
 export const CATEGORY_LABEL: Record<GarmentCategory, string> = {
   hoodie: 'パーカー',
   sweatshirt: 'スウェット',
+  cardigan: 'カーディガン',
   t_shirt: 'Tシャツ',
-  shirt: 'シャツ',
+  tank_top: 'タンクトップ',
+  short_sleeve_shirt: '半袖シャツ',
+  long_sleeve_shirt: '長袖シャツ',
   denim_jacket: 'デニムジャケット',
   swing_top: 'スイングトップ',
   coach_jacket: 'コーチジャケット',


### PR DESCRIPTION
## 概要

古着カテゴリの分類を拡充する。

1. **タンクトップ (`tank_top`) / カーディガン (`cardigan`) を追加** — どちらもトップスとして採寸（肩幅・身幅・着丈・袖丈）
2. **「シャツ」を半袖 / 長袖に分割** — 粗い `shirt` を `short_sleeve_shirt`（半袖シャツ）/ `long_sleeve_shirt`（長袖シャツ）に分ける

## 変更点

### カテゴリ定義 (`packages/shared/src/constants/categories.ts`)
- `GARMENT_CATEGORIES` / `TOP_CATEGORIES` を更新（Tシャツ・タンクトップの並びの後にシャツ2種を配置）
- `CATEGORY_LABEL` に `タンクトップ` / `カーディガン` / `半袖シャツ` / `長袖シャツ` を追加

### DB マイグレーション (`0003_split_shirt_category.sql`)
- 既存の `shirt` レコードを **`long_sleeve_shirt` にリマップ**。分割前は袖丈情報がないため、古着の定番シャツ（オックスフォード / フランネル / ネル / ウエスタン等）で多い長袖を best-effort の既定とした
- 対象4テーブル: `items` / `fit_anchors` / `measurement_rules` / `brand_guides`（`0002_recategorize_legacy_categories` と同じパターン）
- 起動時に `useDbMigrations()` が自動適用

> [!NOTE]
> 実際には半袖だった既存シャツは、アプリ上で個別に半袖シャツへ付け替えてください。

### テスト
- `aggregators.test.ts` / `itemRepository.sold.test.ts` の旧 `category: 'shirt'` フィクスチャを `long_sleeve_shirt` に更新
- `suggestSimilarItems.test.ts` の `'shirt'` はアイテム ID のため変更なし

## 検証

- `pnpm -r typecheck` ✅
- `pnpm --filter @seam/app drizzle:check` ✅
- `pnpm -r test` ✅（222件）
- `pnpm format:check` ✅ / `pnpm lint` ✅

ItemForm・カテゴリピッカーは `GARMENT_CATEGORIES` / `CATEGORY_LABEL` から描画されるため、新カテゴリは自動的に選択肢に反映される。カテゴリ enum の追加・分割のみで testID / UI 構造の変化はないため E2E flow の追加は不要と判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)